### PR TITLE
feat: MainButton 공통 컴포넌트 추가

### DIFF
--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -7,7 +7,7 @@ type MainButtonProps = {
   onClick?: () => void;
 };
 
-const BASE_BUTTON_CLASSES = 'block rounded-[5px] text-[16px] w-[294px] h-[50px]';
+const BASE_BUTTON_CLASSES = 'block rounded-md text-base w-[18.375rem] h-[3.125rem]';
 
 const getModeClasses = (mode: MainButtonProps['mode']) => {
   if (mode === 'filled') {

--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+
+type MainButtonProps = {
+  label: string;
+  mode?: 'filled' | 'outlined';
+  type?: 'button' | 'submit' | 'reset';
+  onClick?: () => void;
+};
+
+const BASE_BUTTON_CLASSES =
+  'block bg-footer-icon rounded-[5px] text-[16px] text-white w-[294px] h-[50px]';
+
+const getModeClasses = (mode: MainButtonProps['mode']) => {
+  if (mode === 'filled') {
+    return 'bg-footer-icon text-white font-Cafe24Surround hover:bg-wall-street';
+  } else if (mode === 'outlined') {
+    return 'bg-transparent border border-1 border-wall-street text-wall-street font-Cafe24SurroundAir hover:bg-footer-icon hover:border-none hover:text-white';
+  }
+};
+
+const MainButton = ({
+  label = '메인버튼',
+  mode = 'filled',
+  type = 'button',
+  onClick,
+  ...props
+}: MainButtonProps) => {
+  const computedClasses = useMemo(() => {
+    return getModeClasses(mode);
+  }, [mode]);
+
+  return (
+    <button
+      className={`${BASE_BUTTON_CLASSES} ${computedClasses}`}
+      type={type}
+      onClick={onClick}
+      {...props}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default MainButton;

--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -7,8 +7,7 @@ type MainButtonProps = {
   onClick?: () => void;
 };
 
-const BASE_BUTTON_CLASSES =
-  'block bg-footer-icon rounded-[5px] text-[16px] text-white w-[294px] h-[50px]';
+const BASE_BUTTON_CLASSES = 'block rounded-[5px] text-[16px] w-[294px] h-[50px]';
 
 const getModeClasses = (mode: MainButtonProps['mode']) => {
   if (mode === 'filled') {

--- a/src/stories/MainButton.stories.tsx
+++ b/src/stories/MainButton.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta, StoryObj } from '@storybook/react';
+import MainButton from '@/components/MainButton';
+
+const meta = {
+  title: 'MainButton',
+  component: MainButton,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    mode: { control: 'inline-radio', options: ['filled', 'outlined'] },
+  },
+} as Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SignUp: Story = {
+  args: {
+    label: '회원가입',
+    mode: 'outlined',
+  },
+};
+
+export const Login: Story = {
+  args: {
+    label: '로그인',
+    mode: 'filled',
+  },
+};


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #17 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
스타일 입힌 메인 버튼 컴포넌트입니다.
hover 스타일이 추가되어 있습니다. (확인해주세요.)
## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/6f50ab72-3539-41fc-b345-34667e649bc2)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/33c5166c-36c3-46db-8ec1-6189ece1e13c)


## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- (이슈-브랜치생성-커밋-푸시-PR 하는데 30분 넘게 걸린 듯 합니다. 엄청 헤맸네요.)
- 사이즈를 정확한 px로 하고 있습니다.
- 버튼의 `label`을 프롭으로 받고 있습니다.
  - 기존 html 버튼 태그는 `<button>버튼라벨</button>`식으로 했지만, `<MainButton label="버튼라벨" />` 이렇게 해야 합니다.
- `block` 요소로 정해뒀는데, 혹시 `inline-block`이 필요할 가능성이 있을까요?
- px에서 rem으로 수정했습니다. rounded는 tailwind에서 제공하는 사이즈 (`md`)로 했습니다.