### PR TITLE
design: article-info-icon 공통 컴포넌트 구현

### DIFF
--- a/src/components/ArticleInfoIcon.tsx
+++ b/src/components/ArticleInfoIcon.tsx
@@ -13,20 +13,19 @@ const ModeClasses = {
 };
 
 const ArticleInfoIcon = ({ likes, comments, mode = 'list' }: ArticleInfoIconProps) => {
+  const spanStyle = 'flex items-center text-wall-street text-[0.75rem] h-[0.75rem] ml-0.5';
+  const iconStyle = 'icon w-[0.9rem] fill-lazy-gray';
+
   return (
     <div className={`flex w-[6.25rem] ${ModeClasses[mode]}`}>
       <div className="flex items-center">
-        <HiThumbUp className="icon w-[0.9rem] fill-lazy-gray" />
-        <span className="flex items-center text-wall-street text-[0.75rem] h-[0.75rem]">
-          {likes}
-        </span>
+        <HiThumbUp className={iconStyle} />
+        <span className={spanStyle}>{likes}</span>
       </div>
       <div className="space w-[1rem]" />
       <div className="flex items-center">
-        <BiSolidComment className="icon w-[0.9rem] fill-lazy-gray" />
-        <span className="flex items-center text-wall-street text-[0.75rem] h-[0.75rem]">
-          {comments}
-        </span>
+        <BiSolidComment className={iconStyle} />
+        <span className={spanStyle}>{comments}</span>
       </div>
     </div>
   );

--- a/src/components/ArticleInfoIcon.tsx
+++ b/src/components/ArticleInfoIcon.tsx
@@ -1,0 +1,35 @@
+import { BiSolidComment } from 'react-icons/bi';
+import { HiThumbUp } from 'react-icons/hi';
+
+type ArticleInfoIconProps = {
+  likes: number;
+  comments: number;
+  mode?: 'list' | 'post';
+};
+
+const ModeClasses = {
+  list: 'justify-start',
+  post: 'justify-end',
+};
+
+const ArticleInfoIcon = ({ likes, comments, mode = 'list' }: ArticleInfoIconProps) => {
+  return (
+    <div className={`flex w-[6.25rem] ${ModeClasses[mode]}`}>
+      <div className="flex items-center">
+        <HiThumbUp className="icon w-[0.9rem] fill-lazy-gray" />
+        <span className="flex items-center text-wall-street text-[0.75rem] h-[0.75rem]">
+          {likes}
+        </span>
+      </div>
+      <div className="space w-[1rem]" />
+      <div className="flex items-center">
+        <BiSolidComment className="icon w-[0.9rem] fill-lazy-gray" />
+        <span className="flex items-center text-wall-street text-[0.75rem] h-[0.75rem]">
+          {comments}
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default ArticleInfoIcon;

--- a/src/stories/ArticleInfoIcon.stories.tsx
+++ b/src/stories/ArticleInfoIcon.stories.tsx
@@ -1,0 +1,36 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ArticleInfoIcon from '@/components/ArticleInfoIcon';
+
+const meta = {
+  title: 'ArticleInfoIcon',
+  component: ArticleInfoIcon,
+  tags: ['autodocs'],
+  argTypes: {
+    likes: { control: 'number' },
+    comments: { control: 'number' },
+    mode: { control: 'inline-radio', options: ['list', 'post'] },
+  },
+  args: {
+    likes: 0,
+    comments: 0,
+    mode: 'list',
+  },
+} as Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const ArticleInfoIconInList: Story = {
+  args: {
+    mode: 'list',
+  },
+};
+
+export const ArticleInfoIconInPost: Story = {
+  args: {
+    mode: 'post',
+  },
+};


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #36 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 응원하기 아이콘, 댓글 아이콘 컴포넌트를 구현했습니다. 
- 'list'는 게시물 목록에서 보여질 때, 'post'는 글 상세 페이지에서 보여질 때입니다. 

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/98521882/9bacdf3e-633f-4e9d-88c1-8a25213e3f52)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 해당 게시물의 id를 받는 prop을 만들어야 할까 고민하다가 우선 컴포넌트 디자인만 구현하는 거라서 뺐습니다. 
- Post 모델을 보니까 likes와 comments는 배열 길이로 받아줘야 하는 것 같은데 맞나요? 