### PR TITLE
Feat: 비밀번호 보여주는 토글버튼 추가

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -9,7 +9,7 @@ export const checkAuthentication = async () => {
   if (token) {
     const { data } = await axiosClient.get<User>(CHECK_AUTH_URL, {
       headers: {
-        Authorization: `Bearer ${JSON.parse(token)}`,
+        Authorization: `Bearer ${token}`,
       },
     });
     return data;

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -1,12 +1,18 @@
 import { RegisterOptions, useFormContext } from 'react-hook-form';
+import {AiOutlineEye, AiOutlineEyeInvisible} from 'react-icons/ai'
 import ErrorText from './ErrorText';
 
-type FormInputProps = {
+
+type FormInputProps =  {
   name: string;
   label: string;
   placeholder: string;
   type?: string;
   registerOptions?: RegisterOptions;
+  onChange?: () => void;
+  isPassword?:boolean;
+  toggleShowPassword?:()=>void;
+  showPassword?:boolean
 };
 
 const defaultInputClass =
@@ -18,6 +24,10 @@ const FormInput = ({
   placeholder,
   type = 'text',
   registerOptions,
+  onChange,
+  isPassword = false,
+  toggleShowPassword,
+  showPassword = false,
   ...props
 }: FormInputProps) => {
   const {
@@ -29,6 +39,7 @@ const FormInput = ({
       <label htmlFor={name} className="font-Cafe24Surround text-footer-icon p-2">
         {label}
       </label>
+      <div className='relative'>
       <input
         className={`${defaultInputClass}
             ${errors[name] ? 'border-error-red' : ''}`}
@@ -36,8 +47,11 @@ const FormInput = ({
         placeholder={placeholder}
         type={type}
         {...register(name, registerOptions)}
+        onChange={onChange}
         {...props}
       />
+      {isPassword && <button className='absolute right-4 top-1/2 -translate-y-1/2' onClick={toggleShowPassword} type='button'>{showPassword ? <AiOutlineEye/> : <AiOutlineEyeInvisible/>}</button>}
+      </div>
       {errors[name] && <ErrorText text={errors[name]?.message as string} />}
     </div>
   );

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -9,10 +9,10 @@ type FormInputProps =  {
   placeholder: string;
   type?: string;
   registerOptions?: RegisterOptions;
-  onChange?: () => void;
   isPassword?:boolean;
   toggleShowPassword?:()=>void;
-  showPassword?:boolean
+  showPassword?:boolean;
+  showToggleButton?:boolean;
 };
 
 const defaultInputClass =
@@ -24,16 +24,17 @@ const FormInput = ({
   placeholder,
   type = 'text',
   registerOptions,
-  onChange,
   isPassword = false,
   toggleShowPassword,
   showPassword = false,
+  showToggleButton=false,
   ...props
 }: FormInputProps) => {
   const {
     register,
     formState: { errors },
   } = useFormContext();
+
   return (
     <div className="flex flex-col">
       <label htmlFor={name} className="font-Cafe24Surround text-footer-icon p-2">
@@ -47,10 +48,9 @@ const FormInput = ({
         placeholder={placeholder}
         type={type}
         {...register(name, registerOptions)}
-        onChange={onChange}
         {...props}
       />
-      {isPassword && <button className='absolute right-4 top-1/2 -translate-y-1/2' onClick={toggleShowPassword} type='button'>{showPassword ? <AiOutlineEye/> : <AiOutlineEyeInvisible/>}</button>}
+      {isPassword && showToggleButton && <button className='absolute right-4 top-1/2 -translate-y-1/2' onClick={toggleShowPassword} type='button'>{showPassword ? <AiOutlineEye/> : <AiOutlineEyeInvisible/>}</button>}
       </div>
       {errors[name] && <ErrorText text={errors[name]?.message as string} />}
     </div>

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -1,18 +1,17 @@
 import { RegisterOptions, useFormContext } from 'react-hook-form';
-import {AiOutlineEye, AiOutlineEyeInvisible} from 'react-icons/ai'
+import { AiOutlineEye, AiOutlineEyeInvisible } from 'react-icons/ai';
 import ErrorText from './ErrorText';
 
-
-type FormInputProps =  {
+type FormInputProps = {
   name: string;
   label: string;
   placeholder: string;
   type?: string;
   registerOptions?: RegisterOptions;
-  isPassword?:boolean;
-  toggleShowPassword?:()=>void;
-  showPassword?:boolean;
-  showToggleButton?:boolean;
+  isPassword?: boolean;
+  toggleShowPassword?: () => void;
+  showPassword?: boolean;
+  showToggleButton?: boolean;
 };
 
 const defaultInputClass =
@@ -27,7 +26,7 @@ const FormInput = ({
   isPassword = false,
   toggleShowPassword,
   showPassword = false,
-  showToggleButton=false,
+  showToggleButton = false,
   ...props
 }: FormInputProps) => {
   const {
@@ -40,17 +39,25 @@ const FormInput = ({
       <label htmlFor={name} className="font-Cafe24Surround text-footer-icon p-2">
         {label}
       </label>
-      <div className='relative'>
-      <input
-        className={`${defaultInputClass}
+      <div className="relative">
+        <input
+          className={`${defaultInputClass}
             ${errors[name] ? 'border-error-red' : ''}`}
-        id={name}
-        placeholder={placeholder}
-        type={type}
-        {...register(name, registerOptions)}
-        {...props}
-      />
-      {isPassword && showToggleButton && <button className='absolute right-4 top-1/2 -translate-y-1/2' onClick={toggleShowPassword} type='button'>{showPassword ? <AiOutlineEye/> : <AiOutlineEyeInvisible/>}</button>}
+          id={name}
+          placeholder={placeholder}
+          type={type}
+          {...register(name, registerOptions)}
+          {...props}
+        />
+        {isPassword && showToggleButton && (
+          <button
+            className="absolute right-4 top-1/2 -translate-y-1/2"
+            onClick={toggleShowPassword}
+            type="button"
+          >
+            {showPassword ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
+          </button>
+        )}
       </div>
       {errors[name] && <ErrorText text={errors[name]?.message as string} />}
     </div>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, createContext, useEffect, useState } from 'react';
 import type { User } from '@/type/User';
+import { removeItemFromStorage } from '@/utils/localStorage';
 import { checkAuthentication } from '@api/auth';
 
 type AuthContextValues = {
@@ -18,7 +19,12 @@ export const AuthContextProvider = ({ children }: { children: ReactNode }) => {
   const fetchUser = async () => {
     try {
       const fetchedUser = await checkAuthentication();
-      fetchedUser ? setUser(fetchedUser) : setUser(null);
+      if(fetchedUser){
+        setUser(fetchedUser)
+      }else{
+        setUser(null)
+        removeItemFromStorage('token')
+      }
     } catch (error) {
       alert(JSON.stringify(error));
     }

--- a/src/hooks/useSignUp.tsx
+++ b/src/hooks/useSignUp.tsx
@@ -9,7 +9,6 @@ const useSignUp = () => {
   const { setUser } = useAuthContext();
   const { mutate: signUpMutate, isLoading } = useMutation(signUp, {
     onSuccess: ({ user, token }) => {
-      // TODO: save the user in the state
       alert(JSON.stringify(user));
       setUser(user);
       setItemToStorage('token', token);

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import { useState } from 'react';
 import { useForm, SubmitHandler, FormProvider } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import MainButton from '@/components/MainButton';
@@ -13,38 +13,40 @@ type SignUpFormValues = {
   passwordCheck: string;
 };
 
-const [EMAIL,PASSWORD,PASSWORD_CHECK,NICKNAME]: (keyof SignUpFormValues)[]= ['email',
-'password',
-'passwordCheck',
-'nickname']
+const [EMAIL, PASSWORD, PASSWORD_CHECK, NICKNAME]: (keyof SignUpFormValues)[] = [
+  'email',
+  'password',
+  'passwordCheck',
+  'nickname',
+];
 
-const INPUT_LABEL:{[key:string]:string} = {
-  EMAIL:'이메일',
-  PASSWORD:'비밀번호',
-  PASSWORD_CHECK:'비밀번호 확인',
-  NICKNAME:'닉네임'
-}
+const INPUT_LABEL: { [key: string]: string } = {
+  EMAIL: '이메일',
+  PASSWORD: '비밀번호',
+  PASSWORD_CHECK: '비밀번호 확인',
+  NICKNAME: '닉네임',
+};
 
-const PLACEHOLDER:{[key:string]:string}={
-  EMAIL: "이메일을 입력해주세요",
-  PASSWORD: "비밀번호를 입력해주세요",
-  PASSWORD_CHECK:"비밀번호를 한번 더 입력해주세요",
-  NICKNAME:"닉네임을 입력해주세요"
-}
+const PLACEHOLDER: { [key: string]: string } = {
+  EMAIL: '이메일을 입력해주세요',
+  PASSWORD: '비밀번호를 입력해주세요',
+  PASSWORD_CHECK: '비밀번호를 한번 더 입력해주세요',
+  NICKNAME: '닉네임을 입력해주세요',
+};
 
-const ERROR_MESSAGE:{[key:string]:string}={
+const ERROR_MESSAGE: { [key: string]: string } = {
   EMPTY_EMAIL: '이메일은 필수입니다!',
-  INVALID_EMAIL:'이메일 형식에 맞지 않습니다!',
-  EMPTY_PASSWORD:'비밀번호는 필수입니다!',
-  INVALID_PASSWORD:'영문, 숫자, 특수기호로 입력해주세요!',
-  SHORT_PASSWORD:'8글자 이상 입력해주세요!',
-  EMPTY_PASSWORD_CHECK: '비밀번호 확인은 필수입니다!', 
-  INVALID_PASSWORD_CHECK:'비밀번호와 일치하지 않습니다!',
-  EMPTY_NICKNAME:'닉네임은 필수입니다!',
-  INVALID_NICKNAME:'한글, 영문, 숫자로 입력해주세요!',
-  SHORT_NICKNAME:'2글자 이상으로 입력해주세요!',
-  LONG_NICKNAME:'10글자 이하로 입력해주세요!'
-}
+  INVALID_EMAIL: '이메일 형식에 맞지 않습니다!',
+  EMPTY_PASSWORD: '비밀번호는 필수입니다!',
+  INVALID_PASSWORD: '영문, 숫자, 특수기호로 입력해주세요!',
+  SHORT_PASSWORD: '8글자 이상 입력해주세요!',
+  EMPTY_PASSWORD_CHECK: '비밀번호 확인은 필수입니다!',
+  INVALID_PASSWORD_CHECK: '비밀번호와 일치하지 않습니다!',
+  EMPTY_NICKNAME: '닉네임은 필수입니다!',
+  INVALID_NICKNAME: '한글, 영문, 숫자로 입력해주세요!',
+  SHORT_NICKNAME: '2글자 이상으로 입력해주세요!',
+  LONG_NICKNAME: '10글자 이하로 입력해주세요!',
+};
 
 const SignUpPage = () => {
   const methods = useForm<SignUpFormValues>();
@@ -60,8 +62,8 @@ const SignUpPage = () => {
     navigate('/login');
   };
 
-  const {watch,trigger} = methods
-  const [password,passwordCheck] = [watch(PASSWORD),watch(PASSWORD_CHECK)]
+  const { watch, trigger } = methods;
+  const [password, passwordCheck] = [watch(PASSWORD), watch(PASSWORD_CHECK)];
 
   return (
     <div className="flex flex-col items-center h-[100vh]">
@@ -71,81 +73,81 @@ const SignUpPage = () => {
           onSubmit={methods.handleSubmit(onSubmit)}
           className="flex flex-col items-center font-bold gap-8"
         >
-         <div className="w-full">
-          <FormInput
-            name={EMAIL}
-            label={INPUT_LABEL.EMAIL}
-            registerOptions={{
-              required: ERROR_MESSAGE.EMPTY_EMAIL,
-              pattern: {
-                value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                message: ERROR_MESSAGE.INVALID_EMAIL,
-              },
-            }}
-            placeholder={PLACEHOLDER.EMAIL}
-          />
-          <FormInput
-            name={PASSWORD}
-            label={INPUT_LABEL.PASSWORD}
-            registerOptions={{
-              required: ERROR_MESSAGE.EMPTY_PASSWORD,
-              pattern: {
-                value: /^[A-Za-z0-9@$!%*#?&]+$/,
-                message: ERROR_MESSAGE.INVALID_PASSWORD,
-              },
-              minLength: {
-                value: 8,
-                message: ERROR_MESSAGE.SHORT_PASSWORD,
-              },
-              onChange:async()=>{
-                await trigger(PASSWORD);
-              }
-            }}
-            type={showPassword ? 'text':'password'}
-            placeholder={PLACEHOLDER.PASSWORD}
-            isPassword={true}
-            showPassword={showPassword}
-            toggleShowPassword={()=>setShowPassword(prev=>!prev)}
-            showToggleButton={!!password}
-          />
-          <FormInput
-            name={PASSWORD_CHECK}
-            label={INPUT_LABEL.PASSWORD_CHECK}
-            registerOptions={{
-              required: ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
-              validate: (value, { password }) =>
-                value === password || ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
-              onChange:async()=>{
+          <div className="w-full">
+            <FormInput
+              name={EMAIL}
+              label={INPUT_LABEL.EMAIL}
+              registerOptions={{
+                required: ERROR_MESSAGE.EMPTY_EMAIL,
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: ERROR_MESSAGE.INVALID_EMAIL,
+                },
+              }}
+              placeholder={PLACEHOLDER.EMAIL}
+            />
+            <FormInput
+              name={PASSWORD}
+              label={INPUT_LABEL.PASSWORD}
+              registerOptions={{
+                required: ERROR_MESSAGE.EMPTY_PASSWORD,
+                pattern: {
+                  value: /^[A-Za-z0-9@$!%*#?&]+$/,
+                  message: ERROR_MESSAGE.INVALID_PASSWORD,
+                },
+                minLength: {
+                  value: 8,
+                  message: ERROR_MESSAGE.SHORT_PASSWORD,
+                },
+                onChange: async () => {
+                  await trigger(PASSWORD);
+                },
+              }}
+              type={showPassword ? 'text' : 'password'}
+              placeholder={PLACEHOLDER.PASSWORD}
+              isPassword={true}
+              showPassword={showPassword}
+              toggleShowPassword={() => setShowPassword((prev) => !prev)}
+              showToggleButton={!!password}
+            />
+            <FormInput
+              name={PASSWORD_CHECK}
+              label={INPUT_LABEL.PASSWORD_CHECK}
+              registerOptions={{
+                required: ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
+                validate: (value, { password }) =>
+                  value === password || ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
+                onChange: async () => {
                   await trigger(PASSWORD_CHECK);
-                }
-            }}
-            type={showPassword ? 'text' : 'password'}
-            placeholder={PLACEHOLDER.PASSWORD_CHECK}
-            isPassword={true}
-            showPassword={showPassword}
-            toggleShowPassword={()=>setShowPassword(prev=>!prev)}
-            showToggleButton={!!passwordCheck}
-          />
-          <FormInput
-            name={NICKNAME}
-            label={INPUT_LABEL.NICKNAME}
-            registerOptions={{
-              required: ERROR_MESSAGE.EMPTY_NICKNAME,
-              pattern: {
-                value: /^[A-Za-z0-9가-힣]+$/,
-                message: ERROR_MESSAGE.INVALID_NICKNAME,
-              },
-              minLength: {
-                value: 2,
-                message: ERROR_MESSAGE.SHORT_NICKNAME,
-              },
-              maxLength: {
-                value: 10,
-                message: ERROR_MESSAGE.LONG_NICKNAME,
-              },
-            }}
-            placeholder={PLACEHOLDER.NICKNAME}
-          />
+                },
+              }}
+              type={showPassword ? 'text' : 'password'}
+              placeholder={PLACEHOLDER.PASSWORD_CHECK}
+              isPassword={true}
+              showPassword={showPassword}
+              toggleShowPassword={() => setShowPassword((prev) => !prev)}
+              showToggleButton={!!passwordCheck}
+            />
+            <FormInput
+              name={NICKNAME}
+              label={INPUT_LABEL.NICKNAME}
+              registerOptions={{
+                required: ERROR_MESSAGE.EMPTY_NICKNAME,
+                pattern: {
+                  value: /^[A-Za-z0-9가-힣]+$/,
+                  message: ERROR_MESSAGE.INVALID_NICKNAME,
+                },
+                minLength: {
+                  value: 2,
+                  message: ERROR_MESSAGE.SHORT_NICKNAME,
+                },
+                maxLength: {
+                  value: 10,
+                  message: ERROR_MESSAGE.LONG_NICKNAME,
+                },
+              }}
+              placeholder={PLACEHOLDER.NICKNAME}
+            />
           </div>
           <div className="flex flex-col gap-4">
             <MainButton label="회원가입" type="submit" isLoading={isLoading} />

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -53,6 +53,9 @@ const SignUpPage = () => {
     signUpMutate({ email, password, nickname });
   };
 
+  const {watch,trigger} = methods
+  const [password,passwordCheck] = [watch(PASSWORD),watch(PASSWORD_CHECK)]
+
   return (
     <div className="flex flex-col items-center">
       <h2 className="">회원가입 페이지</h2>
@@ -86,12 +89,16 @@ const SignUpPage = () => {
                 value: 8,
                 message: ERROR_MESSAGE.SHORT_PASSWORD,
               },
+              onChange:async()=>{
+                await trigger(PASSWORD);
+              }
             }}
             type={showPassword ? 'text':'password'}
             placeholder={PLACEHOLDER.PASSWORD}
             isPassword={true}
             showPassword={showPassword}
             toggleShowPassword={()=>setShowPassword(prev=>!prev)}
+            showToggleButton={!!password}
           />
           <FormInput
             name={PASSWORD_CHECK}
@@ -99,13 +106,17 @@ const SignUpPage = () => {
             registerOptions={{
               required: ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
               validate: (value, { password }) =>
-                value === password || ERROR_MESSAGE.INVALID_PASSWORD_CHECK
+                value === password || ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
+              onChange:async()=>{
+                  await trigger(PASSWORD_CHECK);
+                }
             }}
-            type={showPassword ? 'password' : 'text'}
+            type={showPassword ? 'text' : 'password'}
             placeholder={PLACEHOLDER.PASSWORD_CHECK}
             isPassword={true}
             showPassword={showPassword}
             toggleShowPassword={()=>setShowPassword(prev=>!prev)}
+            showToggleButton={!!passwordCheck}
           />
           <FormInput
             name={NICKNAME}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -87,7 +87,7 @@ const SignUpPage = () => {
                 message: ERROR_MESSAGE.SHORT_PASSWORD,
               },
             }}
-            type={showPassword ? 'password' : 'text'}
+            type={showPassword ? 'text':'password'}
             placeholder={PLACEHOLDER.PASSWORD}
             isPassword={true}
             showPassword={showPassword}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -10,6 +10,39 @@ type SignUpFormValues = {
   passwordCheck: string;
 };
 
+const [EMAIL,PASSWORD,PASSWORD_CHECK,NICKNAME]= ['email',
+'password',
+'passwordCheck',
+'nickname']
+
+const INPUT_LABEL:{[key:string]:string} = {
+  EMAIL:'이메일',
+  PASSWORD:'비밀번호',
+  PASSWORD_CHECK:'비밀번호 확인',
+  NICKNAME:'닉네임'
+}
+
+const PLACEHOLDER:{[key:string]:string}={
+  EMAIL: "이메일을 입력해주세요",
+  PASSWORD: "비밀번호를 입력해주세요",
+  PASSWORD_CHECK:"비밀번호를 한번 더 입력해주세요",
+  NICKNAME:"닉네임을 입력해주세요"
+}
+
+const ERROR_MESSAGE:{[key:string]:string}={
+  EMPTY_EMAIL: '이메일은 필수입니다!',
+  INVALID_EMAIL:'이메일 형식에 맞지 않습니다!',
+  EMPTY_PASSWORD:'비밀번호는 필수입니다!',
+  INVALID_PASSWORD:'영문, 숫자, 특수기호로 입력해주세요!',
+  SHORT_PASSWORD:'8글자 이상 입력해주세요!',
+  EMPTY_PASSWORD_CHECK: '비밀번호 확인은 필수입니다!', 
+  INVALID_PASSWORD_CHECK:'비밀번호와 일치하지 않습니다!',
+  EMPTY_NICKNAME:'닉네임은 필수입니다!',
+  INVALID_NICKNAME:'한글, 영문, 숫자로 입력해주세요!',
+  SHORT_NICKNAME:'2글자 이상으로 입력해주세요!',
+  LONG_NICKNAME:'10글자 이하로 입력해주세요!'
+}
+
 const SignUpPage = () => {
   const methods = useForm<SignUpFormValues>();
   const { signUpMutate, isLoading } = useSignUp();
@@ -26,65 +59,64 @@ const SignUpPage = () => {
           className="flex flex-col font-bold p-4 px-16"
         >
           <FormInput
-            name="email"
-            label="이메일"
+            name={EMAIL}
+            label={INPUT_LABEL.EMAIL}
             registerOptions={{
-              required: '이메일은 필수입니다!',
+              required: ERROR_MESSAGE.EMPTY_EMAIL,
               pattern: {
                 value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                message: '이메일 형식에 맞지 않습니다!',
+                message: ERROR_MESSAGE.INVALID_EMAIL,
               },
             }}
-            type="email"
-            placeholder="이메일을 입력해주세요"
+            placeholder={PLACEHOLDER.EMAIL}
           />
           <FormInput
-            name="password"
-            label="비밀번호"
+            name={PASSWORD}
+            label={INPUT_LABEL.PASSWORD}
             registerOptions={{
-              required: '비밀번호는 필수입니다!',
+              required: ERROR_MESSAGE.EMPTY_PASSWORD,
               pattern: {
                 value: /^[A-Za-z0-9@$!%*#?&]+$/,
-                message: '영문, 숫자, 특수기호로 입력해주세요!',
+                message: ERROR_MESSAGE.INVALID_PASSWORD,
               },
               minLength: {
                 value: 8,
-                message: '8글자 이상 입력해주세요!',
+                message: ERROR_MESSAGE.SHORT_PASSWORD,
               },
             }}
             type="password"
-            placeholder="비밀번호를 입력해주세요"
+            placeholder={PLACEHOLDER.PASSWORD}
           />
           <FormInput
-            name="passwordCheck"
-            label="비밀번호확인"
+            name={PASSWORD_CHECK}
+            label={INPUT_LABEL.PASSWORD_CHECK}
             registerOptions={{
-              required: '비밀번호 확인은 필수입니다!',
+              required: ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
               validate: (value, { password }) =>
-                value === password || '비밀번호와 일치하지 않습니다!',
+                value === password || ERROR_MESSAGE.INVALID_PASSWORD
             }}
             type="password"
-            placeholder="비밀번호를 한번 더 입력해주세요!"
+            placeholder={PLACEHOLDER.PASSWORD}
           />
           <FormInput
-            name="nickname"
-            label="닉네임"
+            name={NICKNAME}
+            label={INPUT_LABEL.NICKNAME}
             registerOptions={{
-              required: '닉네임은 필수입니다!',
+              required: ERROR_MESSAGE.EMPTY_NICKNAME,
               pattern: {
                 value: /^[A-Za-z0-9가-힣]+$/,
-                message: '한글, 영문, 숫자로 입력해주세요!',
+                message: ERROR_MESSAGE.INVALID_NICKNAME,
               },
               minLength: {
                 value: 2,
-                message: '2글자 이상으로 입력해주세요!',
+                message: ERROR_MESSAGE.SHORT_NICKNAME,
               },
               maxLength: {
                 value: 10,
-                message: '10글자 이하로 입력해주세요!',
+                message: ERROR_MESSAGE.LONG_NICKNAME,
               },
             }}
-            placeholder="닉네임을 입력해주세요"
+            placeholder={PLACEHOLDER.NICKNAME}
           />
           <button className="mt-2 p-2" disabled={isLoading}>
             {isLoading && <Loader />}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react'
 import { useForm, SubmitHandler, FormProvider } from 'react-hook-form';
 import FormInput from '@components/FormInput';
 import Loader from '@components/Loader';
@@ -10,7 +11,7 @@ type SignUpFormValues = {
   passwordCheck: string;
 };
 
-const [EMAIL,PASSWORD,PASSWORD_CHECK,NICKNAME]= ['email',
+const [EMAIL,PASSWORD,PASSWORD_CHECK,NICKNAME]: (keyof SignUpFormValues)[]= ['email',
 'password',
 'passwordCheck',
 'nickname']
@@ -45,7 +46,9 @@ const ERROR_MESSAGE:{[key:string]:string}={
 
 const SignUpPage = () => {
   const methods = useForm<SignUpFormValues>();
+  const [showPassword, setShowPassword] = useState(false);
   const { signUpMutate, isLoading } = useSignUp();
+
   const onSubmit: SubmitHandler<SignUpFormValues> = ({ email, password, nickname }) => {
     signUpMutate({ email, password, nickname });
   };
@@ -84,8 +87,11 @@ const SignUpPage = () => {
                 message: ERROR_MESSAGE.SHORT_PASSWORD,
               },
             }}
-            type="password"
+            type={showPassword ? 'password' : 'text'}
             placeholder={PLACEHOLDER.PASSWORD}
+            isPassword={true}
+            showPassword={showPassword}
+            toggleShowPassword={()=>setShowPassword(prev=>!prev)}
           />
           <FormInput
             name={PASSWORD_CHECK}
@@ -93,10 +99,13 @@ const SignUpPage = () => {
             registerOptions={{
               required: ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
               validate: (value, { password }) =>
-                value === password || ERROR_MESSAGE.INVALID_PASSWORD
+                value === password || ERROR_MESSAGE.INVALID_PASSWORD_CHECK
             }}
-            type="password"
-            placeholder={PLACEHOLDER.PASSWORD}
+            type={showPassword ? 'password' : 'text'}
+            placeholder={PLACEHOLDER.PASSWORD_CHECK}
+            isPassword={true}
+            showPassword={showPassword}
+            toggleShowPassword={()=>setShowPassword(prev=>!prev)}
           />
           <FormInput
             name={NICKNAME}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #28 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 회원가입에서 사용하는 메시지를 상수로 분리했습니다
- 비밀번호를 보여주는 토글 버튼을 추가했습니다
- 토글 버튼은 비밀번호 또는 비밀번호 확인 값이 입력됐을 때만 보입니다
- user를 fetch받는 부분에서 발생하는 버그를 수정했습니다

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![비밀번호-토글](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43432783/6a54bcf7-82be-4e24-95be-f6efcb4a6db3)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
FormInput에 너무 많은 값을 주입하는 것 같네요 ㅎㅎ...
나중에 구조를 수정하려합니다