### PR TITLE
feat: 로그인하기

### DIFF
--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -13,7 +13,7 @@ type LoginResponseData = {
   token: string;
 };
 
-export const Login = async ({ email, password }: LoginParams): Promise<LoginResponseData> => {
+export const login = async ({ email, password }: LoginParams): Promise<LoginResponseData> => {
   const loginParams: LoginParams = {
     email,
     password,

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -1,0 +1,26 @@
+import type { User } from '@/type/User';
+import { axiosClient } from './axiosClient';
+
+const LOGIN_URL = '/login';
+
+type LoginParams = {
+  email: string;
+  password: string;
+};
+
+type LoginResponseData = {
+  user: User;
+  token: string;
+};
+
+export const Login = async ({ email, password }: LoginParams): Promise<LoginResponseData> => {
+  const loginParams: LoginParams = {
+    email,
+    password,
+  };
+
+  const { data } = await axiosClient.post<LoginResponseData>(LOGIN_URL, {
+    ...loginParams,
+  });
+  return data;
+};

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -14,6 +14,9 @@ const useLogin = () => {
       setItemToStorage('token', token);
       navigate('/home');
     },
+    onError: () => {
+      alert('이메일과 비밀번호를 확인해주세요!');
+    },
   });
   return { loginMutate, isLoading };
 };

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -1,0 +1,21 @@
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { login } from '@api/login';
+import { setItemToStorage } from '@utils/localStorage';
+import { useAuthContext } from './useAuthContext';
+
+const useLogin = () => {
+  const navigate = useNavigate();
+  const { setUser } = useAuthContext();
+  const { mutate: loginMutate, isLoading } = useMutation(login, {
+    onSuccess: ({ user, token }) => {
+      alert(JSON.stringify(user));
+      setUser(user);
+      setItemToStorage('token', token);
+      navigate('/home');
+    },
+  });
+  return { loginMutate, isLoading };
+};
+
+export default useLogin;

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -9,7 +9,7 @@ const useLogin = () => {
   const { setUser } = useAuthContext();
   const { mutate: loginMutate, isLoading } = useMutation(login, {
     onSuccess: ({ user, token }) => {
-      alert(JSON.stringify(user));
+      alert(JSON.stringify(user)); //TODO Toast 메세지로 성공 알리기?
       setUser(user);
       setItemToStorage('token', token);
       navigate('/home');

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,66 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import FormInput from '@/components/FormInput';
+import HeaderText from '@/components/HeaderText';
+import MainButton from '@/components/MainButton';
+
+type LoginFormValue = {
+  email: string;
+  password: string;
+};
+
 const LoginPage = () => {
-  return <h2>로그인</h2>;
+  const methods = useForm<LoginFormValue>();
+  return (
+    // TODO 레이아웃 grid로 잡아보기! 뷰포트 사용하지 말기
+    <div className="flex flex-col items-center w-[100vw] h-[100vh] justify-center bg-white">
+      <div className=" absolute top-[12%]">
+        <HeaderText label="로그인" />
+      </div>
+      <FormProvider {...methods}>
+        <form className="flex flex-col font-bold p-4 px-16 gap-5">
+          <div>
+            <FormInput
+              name="email"
+              label="E-mail"
+              type="email"
+              registerOptions={{
+                required: '이메일은 필수입니다!',
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: '이메일 형식에 맞지 않습니다!',
+                },
+              }}
+              placeholder="이메일을 입력해주세요"
+            />
+            <FormInput
+              name="password"
+              label="Password"
+              type="password"
+              registerOptions={{
+                required: '비밀번호는 필수입니다!',
+                pattern: {
+                  value: /^[A-Za-z0-9@$!%*#?&]+$/,
+                  message: '영문, 숫자, 특수기호로 입력해주세요!',
+                },
+                minLength: {
+                  value: 8,
+                  message: '8글자 이상 입력해주세요!',
+                },
+              }}
+              placeholder="비밀번호를 입력해주세요"
+            />
+          </div>
+          <div className="flex flex-col gap-3 mt-5">
+            <MainButton label="로그인" />
+            <MainButton label="회원가입" mode="outlined" />
+            <button className="font-Cafe24SurroundAir text-[1rem] text-lazy-gray hover:text-wall-street mt-5">
+              홈으로 가기
+            </button>
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
 };
 
 export default LoginPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,59 +1,112 @@
-import { FormProvider, useForm } from 'react-hook-form';
+import { useState } from 'react';
+import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import FormInput from '@/components/FormInput';
 import HeaderText from '@/components/HeaderText';
 import MainButton from '@/components/MainButton';
+import useLogin from '@/hooks/useLogin';
 
-type LoginFormValue = {
+type LoginFormValues = {
   email: string;
   password: string;
 };
 
+const [EMAIL, PASSWORD]: (keyof LoginFormValues)[] = ['email', 'password'];
+
+const INPUT_LABEL: { [key: string]: string } = {
+  EMAIL: '이메일',
+  PASSWORD: '비밀번호',
+};
+
+const PLACEHOLDER: { [key: string]: string } = {
+  EMAIL: '이메일을 입력해주세요',
+  PASSWORD: '비밀번호를 입력해주세요',
+};
+
+const ERROR_MESSAGE: { [key: string]: string } = {
+  EMPTY_EMAIL: '이메일은 필수입니다!',
+  INVALID_EMAIL: '이메일 형식에 맞지 않습니다!',
+  EMPTY_PASSWORD: '비밀번호는 필수입니다!',
+  SHORT_PASSWORD: '8글자 이상 입력해주세요!',
+};
+
 const LoginPage = () => {
-  const methods = useForm<LoginFormValue>();
+  const methods = useForm<LoginFormValues>();
+  const [showPassword, setShowPassword] = useState(false);
+  const { loginMutate, isLoading } = useLogin();
+
+  const onSubmit: SubmitHandler<LoginFormValues> = ({ email, password }) => {
+    loginMutate({ email, password });
+  };
+
+  const navigate = useNavigate();
+
+  const handleClickHomeButton = () => {
+    navigate('/home');
+  };
+
+  const handleClickSignUpButton = () => {
+    navigate('/signup');
+  };
+
+  const { watch, trigger } = methods;
+  const password = watch(PASSWORD);
+
   return (
-    // TODO 레이아웃 grid로 잡아보기! 뷰포트 사용하지 말기
-    <div className="flex flex-col items-center w-[100vw] h-[100vh] justify-center bg-white">
+    <div className="flex flex-col items-center w-[100vw] h-[100vh] justify-center">
       <div className=" absolute top-[12%]">
         <HeaderText label="로그인" />
       </div>
       <FormProvider {...methods}>
-        <form className="flex flex-col font-bold p-4 px-16 gap-5">
+        <form
+          onSubmit={methods.handleSubmit(onSubmit)}
+          className="flex flex-col font-bold p-4 px-16 gap-5"
+        >
           <div>
             <FormInput
-              name="email"
-              label="E-mail"
-              type="email"
+              name={EMAIL}
+              label={INPUT_LABEL.EMAIL}
               registerOptions={{
-                required: '이메일은 필수입니다!',
+                required: ERROR_MESSAGE.EMPTY_EMAIL,
                 pattern: {
                   value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
-                  message: '이메일 형식에 맞지 않습니다!',
+                  message: ERROR_MESSAGE.INVALID_EMAIL,
                 },
               }}
-              placeholder="이메일을 입력해주세요"
+              placeholder={PLACEHOLDER.EMAIL}
             />
             <FormInput
-              name="password"
-              label="Password"
-              type="password"
+              name={PASSWORD}
+              label={INPUT_LABEL.PASSWORD}
               registerOptions={{
-                required: '비밀번호는 필수입니다!',
+                required: ERROR_MESSAGE.EMPTY_PASSWORD,
                 pattern: {
                   value: /^[A-Za-z0-9@$!%*#?&]+$/,
-                  message: '영문, 숫자, 특수기호로 입력해주세요!',
+                  message: ERROR_MESSAGE.INVALID_PASSWORD,
                 },
                 minLength: {
                   value: 8,
-                  message: '8글자 이상 입력해주세요!',
+                  message: ERROR_MESSAGE.SHORT_PASSWORD,
+                },
+                onChange: async () => {
+                  await trigger(PASSWORD);
                 },
               }}
-              placeholder="비밀번호를 입력해주세요"
+              type={showPassword ? 'text' : 'password'}
+              placeholder={PLACEHOLDER.PASSWORD}
+              isPassword={true}
+              showPassword={showPassword}
+              toggleShowPassword={() => setShowPassword((prev) => !prev)}
+              showToggleButton={!!password}
             />
           </div>
           <div className="flex flex-col gap-3 mt-5">
-            <MainButton label="로그인" />
-            <MainButton label="회원가입" mode="outlined" />
-            <button className="font-Cafe24SurroundAir text-[1rem] text-lazy-gray hover:text-wall-street mt-5">
+            <MainButton label="로그인" type="submit" isLoading={isLoading} />
+            <MainButton label="회원가입" mode="outlined" onClick={handleClickSignUpButton} />
+            <button
+              onClick={handleClickHomeButton}
+              className="mt-5 font-Cafe24SurroundAir text-base text-lazy-gray hover:text-wall-street"
+            >
               홈으로 가기
             </button>
           </div>


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #68 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- **기능/로그인하기**
  - 인증된 사용자는 로그인을 할 수 있습니다.
  - 로그인에 성공하면 홈으로 리다이렉션
  - 로그인에 실패하면 alert (useLogin 훅)
- **구현된 UI**
  - 이메일 입력 칸
  - 비밀번호 입력 칸
  - 로그인 버튼
  - 회원가입 버튼
  - (추가됨) 홈으로 가기 버튼

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/7474723e-973a-4e20-ac99-2e615c42f76f)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/1440f890-7dd4-495c-a77f-a72dd70d4448)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/46385e3e-f81b-44fe-8e1b-c5125394d88f)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/11b38b9f-b4a4-496a-8947-206eb9f1ad1f)

![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/29e6bcbb-664c-479a-8f7e-7d8f00cb52c8)
[로그인 실패 시]
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/a466c3f2-df7f-4fa3-b90f-1dbb78e7c118)
[로그인 성공 시]

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 기능 이외 레이아웃 디자인 수정이 필요합니다.
- SignUp 페이지의 코드와 거의 흡사하기에 공통 부분을 묶어서 분리해야 할 것 같습니다.
- 로그인 성공 및 실패에 대한 피드백을 현재는 alert로 처리해두었는데, 이 부분을 어떻게 처리할 지 고민해야 합니다.