### PR TITLE
design: 프로필 수정 페이지 레이아웃

### DIFF
--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -1,0 +1,19 @@
+import CloseButton from '@/components/CloseButton';
+import HeaderText from '@/components/HeaderText';
+import EditForm from './ProfileEditPage/EditForm';
+
+const ProfileEditPage = () => {
+  return (
+    <section className="grid grid-rows-[1fr_8fr] h-screen bg-white overflow-y-auto">
+      <header className="flex justify-center w-full">
+        <div className="flex justify-between items-center p-4 pt-8 w-full max-w-sm">
+          <HeaderText label="프로필 수정" />
+          <CloseButton />
+        </div>
+      </header>
+      <EditForm />
+    </section>
+  );
+};
+
+export default ProfileEditPage;

--- a/src/pages/ProfileEditPage/EditForm.tsx
+++ b/src/pages/ProfileEditPage/EditForm.tsx
@@ -1,0 +1,53 @@
+import { FormEventHandler } from 'react';
+import { BiSolidUser } from 'react-icons/bi';
+import { HiPencil } from 'react-icons/hi';
+import MainButton from '@/components/MainButton';
+
+const textareaAutosize: FormEventHandler<HTMLTextAreaElement> = (event) => {
+  const target = event.target as HTMLTextAreaElement;
+  target.style.height = 'auto';
+  target.style.height = `${target.scrollHeight}px`;
+};
+
+const EditForm = () => {
+  return (
+    <div className="flex justify-center">
+      <form className="p-8 flex flex-col gap-3 max-w-sm w-full">
+        <div className="flex flex-col gap-3">
+          <label htmlFor="" className="text-wall-street font-Cafe24Surround font-bold">
+            프로필 사진
+          </label>
+          <div className="relative w-32 h-32 rounded-full bg-profile-bg self-center mb-6 border border-tertiory-gray text-primary-black">
+            <BiSolidUser className="w-24 h-24 translate-x-4 translate-y-4" />
+            <label
+              htmlFor="image"
+              className="absolute right-1 bottom-1 p-1 rounded-full bg-profile-bg border border-tertiory-gray"
+            >
+              <HiPencil className="w-4 h-4" />
+            </label>
+            <input type="file" accept="image/*" className="hidden" id="image" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-wall-street font-Cafe24Surround font-bold">닉네임</label>
+          <input className="max-w-sm  w-full  p-3.5 bg-input-white outline-none border border-lazy-gray placeholder:text-lazy-gray rounded font-Cafe24SurroundAir" />
+          <small className="self-end font-Cafe24SurroundAir text-sm font-light">7 / 10</small>
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="text-wall-street font-Cafe24Surround font-bold">자기소개</label>
+          <textarea
+            className="max-w-sm  w-full  p-3.5 bg-input-white outline-none border border-lazy-gray placeholder:text-lazy-gray rounded font-Cafe24SurroundAir"
+            onChange={textareaAutosize}
+          />
+          <small className="self-end font-Cafe24SurroundAir text-sm font-light">0 / 30</small>
+        </div>
+        <div className="flex flex-col items-center mt-5 p-5 gap-5">
+          <MainButton label="비밀번호 변경하기" mode="outlined" />
+          <MainButton label="프로필 수정" type="submit" />
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default EditForm;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -8,4 +8,5 @@ export { default as ArticlesPage } from './ArticlesPage';
 export { default as ArticleDetailPage } from './ArticleDetailPage';
 export { default as ProfilePage } from './ProfilePage';
 export { default as SearchPage } from './SearchPage';
-export { default as SignupPage } from './SignupPage';
+export { default as SignUpPage } from './SignupPage';
+export { default as ProfileEditPage } from './ProfileEditPage';

--- a/src/utils/Router.tsx
+++ b/src/utils/Router.tsx
@@ -4,7 +4,7 @@ import {
   HomePage,
   LandingPage,
   NotFoundPage,
-  SignupPage,
+  SignUpPage,
   SearchPage,
   ProfilePage,
   LoginPage,
@@ -12,6 +12,7 @@ import {
   ArticleDetailPage,
   NotificationPage,
   ArticlesPage,
+  ProfileEditPage,
 } from '@pages/index';
 
 const router = createBrowserRouter([
@@ -22,7 +23,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <LandingPage /> },
       { path: 'home', element: <HomePage /> },
-      { path: 'signup', element: <SignupPage /> },
+      { path: 'signUp', element: <SignUpPage /> },
       { path: 'search', element: <SearchPage /> },
       { path: 'profile', element: <ProfilePage /> },
       { path: 'login', element: <LoginPage /> },
@@ -30,6 +31,7 @@ const router = createBrowserRouter([
       { path: 'news/create', element: <NewArticlePage /> },
       { path: 'news/:postId', element: <ArticleDetailPage /> },
       { path: 'notification', element: <NotificationPage /> },
+      { path: 'profile/edit', element: <ProfileEditPage /> },
     ],
   },
 ]);


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #98 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 이슈대로 프로필 수정 페이지 레이아웃을 추가했습니다.
- 프로필 수정 페이지의 url이 없어서 /profile/edit으로 설정해놓았습니다

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

<img width="392" alt="프로필 수정 페이지 레이아웃" src="https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43432783/8c617123-09b6-4871-8b31-879232b44535">

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
게시글 작성, 프로필 수정등의 input, validation이 비슷한 것 같은데 컴포넌트로 만들면 어떨까 하는 생각이 들었습니다

