### PR TITLE
feat: 비밀번호 변경 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,15 +2,15 @@ import { Outlet } from 'react-router-dom';
 import { AuthContextProvider } from './context/AuthContext';
 
 const TempNavBar = () => {
-  const ANCHOR_CLASS = 'border-b border-gray-200 no-underline hover:text-cooled-blue';
+  const ANCHOR_CLASS = 'border-gray-200 no-underline hover:text-cooled-blue';
   return (
-    <header className="absolute w-[20px] h-[20px] top-[20%] z-50">
+    <header className="absolute w-[20px] h-[20px] top-[10%] z-50">
       <div className="bg-white border gap-1 flex flex-col mb-3 rounded-r-xl">
         <a className={ANCHOR_CLASS} href="/news">
           뉴스
         </a>
         <a className={ANCHOR_CLASS} href="/signUp">
-          회원가입
+          가입
         </a>
         <a className={ANCHOR_CLASS} href="/login">
           로그인
@@ -29,6 +29,9 @@ const TempNavBar = () => {
         </a>
         <a className={ANCHOR_CLASS} href="/profile/edit">
           프로필수정
+        </a>
+        <a className={ANCHOR_CLASS} href="/password">
+          비번변경
         </a>
       </div>
     </header>

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -15,7 +15,7 @@ type FormInputProps = {
 };
 
 const defaultInputClass =
-  'max-w-[18.325rem] w-full  p-3.5 bg-input-white outline-none border border-lazy-gray placeholder:text-lazy-gray rounded font-Cafe24SurroundAir';
+  'max-w-[18.325rem] w-full  p-3.5 bg-input-white outline-none border border-lazy-gray placeholder:text-lazy-gray rounded font-Cafe24SurroundAir font-normal';
 
 const FormInput = ({
   name,

--- a/src/components/HeaderText.tsx
+++ b/src/components/HeaderText.tsx
@@ -4,13 +4,13 @@ type HeaderTextProps = {
 };
 
 const HeaderText = ({ size = 'normal', label }: HeaderTextProps) => {
-  const TEXT_BASE_CLASS = 'font-Cafe24Surround text-tricorn-black inline-block';
+  const TEXT_BASE_CLASS = 'font-Cafe24Surround text-tricorn-black inline-block dark:text-white';
   const TEXT_SIZE_CLASS = {
     small: 'text-[1.75rem]',
     normal: 'text-[2rem]',
     large: 'text-[2.5rem]',
   };
-  return <h1 className={`dark:text-white ${TEXT_BASE_CLASS} ${TEXT_SIZE_CLASS[size]}`}>{label}</h1>;
+  return <h1 className={`${TEXT_BASE_CLASS} ${TEXT_SIZE_CLASS[size]}`}>{label}</h1>;
 };
 
 export default HeaderText;

--- a/src/hooks/useChangePassword.tsx
+++ b/src/hooks/useChangePassword.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { updatePassword } from '@api/common/UserSettings';
+
+const useChangePassword = () => {
+  const navigate = useNavigate();
+  const { mutate: changePasswordMutate, isLoading } = useMutation(updatePassword, {
+    onSuccess: () => {
+      alert('비밀번호가 성공적으로 변경되었습니다.');
+      navigate(-1);
+    },
+    onError: (error) => {
+      alert(JSON.stringify(error));
+    },
+  });
+
+  return { changePasswordMutate, isLoading };
+};
+
+export default useChangePassword;

--- a/src/hooks/useChangePassword.tsx
+++ b/src/hooks/useChangePassword.tsx
@@ -7,7 +7,7 @@ const useChangePassword = () => {
   const { mutate: changePasswordMutate, isLoading } = useMutation(updatePassword, {
     onSuccess: () => {
       alert('비밀번호가 성공적으로 변경되었습니다.');
-      navigate(-1);
+      navigate('/home', { replace: true });
     },
     onError: (error) => {
       alert(JSON.stringify(error));

--- a/src/pages/ChangePasswordPage.tsx
+++ b/src/pages/ChangePasswordPage.tsx
@@ -36,7 +36,6 @@ const ERROR_MESSAGE = {
 const ChangePasswordPage = () => {
   const methods = useForm<PasswordFormValues>();
   const [showPassword, setShowPassword] = useState(false);
-  const [showPasswordCheck, setShowPasswordCheck] = useState(false);
   const { changePasswordMutate, isLoading } = useChangePassword();
 
   const onSubmit: SubmitHandler<PasswordFormValues> = ({ password }) => {
@@ -95,11 +94,11 @@ const ChangePasswordPage = () => {
                   await trigger(PASSWORD_CHECK);
                 },
               }}
-              type={showPasswordCheck ? 'text' : 'password'}
+              type={showPassword ? 'text' : 'password'}
               placeholder={PLACEHOLDER.PASSWORD_CHECK}
               isPassword={true}
-              showPassword={showPasswordCheck}
-              toggleShowPassword={() => setShowPasswordCheck((prev) => !prev)}
+              showPassword={showPassword}
+              toggleShowPassword={() => setShowPassword((prev) => !prev)}
               showToggleButton={!!passwordCheck}
             />
           </div>

--- a/src/pages/ChangePasswordPage.tsx
+++ b/src/pages/ChangePasswordPage.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
+import FormInput from '@/components/FormInput';
+import HeaderText from '@/components/HeaderText';
+import MainButton from '@/components/MainButton';
+import useChangePassword from '@hooks/useChangePassword';
+
+type PasswordFormValues = {
+  password: string;
+  passwordCheck: string;
+};
+
+const HEADER_TEXT = '비밀번호 변경';
+
+const [PASSWORD, PASSWORD_CHECK]: (keyof PasswordFormValues)[] = ['password', 'passwordCheck'];
+
+const PLACEHOLDER = {
+  PASSWORD: '변경할 비밀번호를 입력해주세요',
+  PASSWORD_CHECK: '한 번 더 입력해주세요',
+};
+
+const LABELS = {
+  PASSWORD: '비밀번호',
+  PASSWORD_CHECK: '',
+  SUBMIT_BUTTON: '변경하기',
+};
+
+const ERROR_MESSAGE = {
+  EMPTY_PASSWORD: '비밀번호는 필수입니다!',
+  SHORT_PASSWORD: '8글자 이상 입력해주세요!',
+  INVALID_PASSWORD: '영문, 숫자, 특수기호로 입력해주세요!',
+  EMPTY_PASSWORD_CHECK: '비밀번호 확인은 필수입니다!',
+  INVALID_PASSWORD_CHECK: '비밀번호와 일치하지 않습니다!',
+};
+
+const ChangePasswordPage = () => {
+  const methods = useForm<PasswordFormValues>();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showPasswordCheck, setShowPasswordCheck] = useState(false);
+  const { changePasswordMutate, isLoading } = useChangePassword();
+
+  const onSubmit: SubmitHandler<PasswordFormValues> = ({ password }) => {
+    // TODO 추후 모달 방식으로 변경하기
+    if (confirm('비밀번호를 변경하시겠습니까?')) {
+      changePasswordMutate(password);
+    }
+  };
+
+  const { watch, trigger } = methods;
+  const [password, passwordCheck] = [watch(PASSWORD), watch(PASSWORD_CHECK)];
+
+  return (
+    <div className="flex flex-col items-center w-[100vw] h-[100vh] justify-center">
+      <FormProvider {...methods}>
+        <form
+          onSubmit={methods.handleSubmit(onSubmit)}
+          className="flex flex-col items-center p-4 gap-5"
+        >
+          <div className="w-[18.375rem]">
+            <div className="absolute top-[12%]">
+              <HeaderText label={HEADER_TEXT} />
+            </div>
+            <FormInput
+              name={PASSWORD}
+              label={LABELS.PASSWORD}
+              registerOptions={{
+                required: ERROR_MESSAGE.EMPTY_PASSWORD,
+                pattern: {
+                  value: /^[A-Za-z0-9@$!%*#?&]+$/,
+                  message: ERROR_MESSAGE.INVALID_PASSWORD,
+                },
+                minLength: {
+                  value: 8,
+                  message: ERROR_MESSAGE.SHORT_PASSWORD,
+                },
+                onChange: async () => {
+                  await trigger(PASSWORD);
+                },
+              }}
+              type={showPassword ? 'text' : 'password'}
+              placeholder={PLACEHOLDER.PASSWORD}
+              isPassword={true}
+              showPassword={showPassword}
+              toggleShowPassword={() => setShowPassword((prev) => !prev)}
+              showToggleButton={!!password}
+            />
+            <FormInput
+              name={PASSWORD_CHECK}
+              label={LABELS.PASSWORD_CHECK}
+              registerOptions={{
+                required: ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
+                validate: (value, { password }) =>
+                  value === password || ERROR_MESSAGE.INVALID_PASSWORD_CHECK,
+                onChange: async () => {
+                  await trigger(PASSWORD_CHECK);
+                },
+              }}
+              type={showPasswordCheck ? 'text' : 'password'}
+              placeholder={PLACEHOLDER.PASSWORD_CHECK}
+              isPassword={true}
+              showPassword={showPasswordCheck}
+              toggleShowPassword={() => setShowPasswordCheck((prev) => !prev)}
+              showToggleButton={!!passwordCheck}
+            />
+          </div>
+          <div className="absolute bottom-[12%]">
+            <MainButton label={LABELS.SUBMIT_BUTTON} type="submit" isLoading={isLoading} />
+          </div>
+        </form>
+      </FormProvider>
+    </div>
+  );
+};
+
+export default ChangePasswordPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -60,7 +60,7 @@ const LoginPage = () => {
       <FormProvider {...methods}>
         <form
           onSubmit={methods.handleSubmit(onSubmit)}
-          className="flex flex-col font-bold p-4 px-16 gap-5"
+          className="flex flex-col font-bold p-4 gap-5"
         >
           <div>
             <FormInput

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -10,3 +10,4 @@ export { default as ProfilePage } from './ProfilePage';
 export { default as SearchPage } from './SearchPage';
 export { default as SignUpPage } from './SignupPage';
 export { default as ProfileEditPage } from './ProfileEditPage';
+export { default as ChangePasswordPage } from './ChangePasswordPage';

--- a/src/utils/Router.tsx
+++ b/src/utils/Router.tsx
@@ -13,6 +13,7 @@ import {
   NotificationPage,
   ArticlesPage,
   ProfileEditPage,
+  ChangePasswordPage,
 } from '@pages/index';
 
 const router = createBrowserRouter([
@@ -32,6 +33,7 @@ const router = createBrowserRouter([
       { path: 'news/:postId', element: <ArticleDetailPage /> },
       { path: 'notification', element: <NotificationPage /> },
       { path: 'profile/edit', element: <ProfileEditPage /> },
+      { path: 'password', element: <ChangePasswordPage /> },
     ],
   },
 ]);


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #124 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
### 비밀번호 변경 페이지 구현
- **`pages/ChangePasswordPage.tsx`**

### 자잘한 수정
- 라우터 추가(`/password`), 페이지 인덱스 내보내기 추가
- FormInput 인풋 태그 내부 폰트를 bold에서 normal로 수정
- 임시 navbar에 '비번변경' 버튼 추가
- 내용 없는 `temp.tsx` 파일 삭제

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/1a7badee-0afb-4e5b-b080-f226dec6ac91)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 모달 컴포넌트가 아직 개발되지 않아 자바스크립트 confirm으로 확인하게 하였습니다.
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/15d43af6-238b-4348-95d9-b882a001eaad)
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/7d52016b-3296-4338-a613-988def6b0818)

- 비밀번호와 비밀번호 확인 인풋에 각자 다른 상태를 부여하여 눈동자 아이콘이 개별적으로 동작하게 했습니다.