### PR TITLE
design: 글 상세 페이지 레이아웃 구현

### DIFF
--- a/src/components/ArticleDetail.tsx
+++ b/src/components/ArticleDetail.tsx
@@ -1,0 +1,29 @@
+import { getTimeStamp } from '@/utils/getTimeStamp';
+import Avatar from './Avatar';
+
+type ArticleDetailProps = {
+  nickname: string;
+  postedDate: string;
+};
+
+const ArticleDetail = ({ nickname, postedDate }: ArticleDetailProps) => {
+  const timestamp = getTimeStamp(postedDate);
+
+  return (
+    <div className="flex justify-center items-center w-[23rem] min-h-[6rem] p-1 font-Cafe24SurroundAir text-tricorn-black">
+      <div className="flex flex-col w-[22.125rem]">
+        <div className="flex w-[22.125rem] h-[1.5rem]">
+          <div className="icon cursor-pointer">
+            <Avatar width={2.5} profileImage="" isLoggedIn={false} />
+          </div>
+          <div className="ml-3 w-[19.62rem]">
+            <div className="cursor-pointer">{nickname}</div>
+            <div className="text-wall-street text-xs">{timestamp}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ArticleDetail;

--- a/src/components/ArticleDetail.tsx
+++ b/src/components/ArticleDetail.tsx
@@ -17,7 +17,9 @@ const ArticleDetail = ({ nickname, postedDate }: ArticleDetailProps) => {
             <Avatar width={2.5} profileImage="" isLoggedIn={false} />
           </div>
           <div className="ml-3 w-[19.62rem]">
-            <div className="cursor-pointer text-base">{nickname}</div>
+            <div className="text-base">
+              <span className="cursor-pointer">{nickname}</span>
+            </div>
             <div className="text-wall-street text-[10px]">{timestamp}</div>
           </div>
         </div>

--- a/src/components/ArticleDetail.tsx
+++ b/src/components/ArticleDetail.tsx
@@ -10,15 +10,15 @@ const ArticleDetail = ({ nickname, postedDate }: ArticleDetailProps) => {
   const timestamp = getTimeStamp(postedDate);
 
   return (
-    <div className="flex justify-center items-center w-[23rem] min-h-[6rem] p-1 font-Cafe24SurroundAir text-tricorn-black">
+    <div className="flex justify-center items-center w-[23rem] min-h-[5rem] p-1 font-Cafe24SurroundAir text-tricorn-black">
       <div className="flex flex-col w-[22.125rem]">
         <div className="flex w-[22.125rem] h-[1.5rem]">
           <div className="icon cursor-pointer">
             <Avatar width={2.5} profileImage="" isLoggedIn={false} />
           </div>
           <div className="ml-3 w-[19.62rem]">
-            <div className="cursor-pointer">{nickname}</div>
-            <div className="text-wall-street text-xs">{timestamp}</div>
+            <div className="cursor-pointer text-base">{nickname}</div>
+            <div className="text-wall-street text-[10px]">{timestamp}</div>
           </div>
         </div>
       </div>

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,3 +1,4 @@
+import { getTimeStamp } from '@/utils/getTimeStamp';
 import Avatar from './Avatar';
 import CloseButton from './CloseButton';
 
@@ -8,20 +9,8 @@ type CommentProps = {
   active: boolean;
 };
 
-const getTimestamp = (postedDate: string) => {
-  const dt = new Date(postedDate);
-  const [year, month, date, hours, minutes] = [
-    dt.getFullYear().toString().slice(-2),
-    dt.getMonth() + 1,
-    dt.getDate(),
-    dt.getHours(),
-    dt.getMinutes(),
-  ];
-  return `${year}/${month}/${date} ${hours}:${minutes}`;
-};
-
 const Comment = ({ nickname, content, postedDate, active }: CommentProps) => {
-  const timestamp = getTimestamp(postedDate);
+  const timestamp = getTimeStamp(postedDate);
 
   return (
     <div className="flex justify-center items-center w-[23rem] min-h-[6rem] p-1">

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -13,21 +13,22 @@ const Comment = ({ nickname, content, postedDate, active }: CommentProps) => {
   const timestamp = getTimeStamp(postedDate);
 
   return (
-    <div className="flex justify-center items-center w-[23rem] min-h-[6rem] p-1">
-      <div className="flex flex-col w-[22.125rem]  font-Cafe24SurroundAir">
-        <div className="flex w-[22.125rem] h-[1.5rem]">
+    <div className="flex justify-center items-center w-[20rem] min-h-[6rem] mt-3">
+      <div className="flex flex-col w-[20rem]  font-Cafe24SurroundAir">
+        <div className="flex w-[20rem] h-[1.5rem]">
           <div className="icon cursor-pointer">
             <Avatar width={1.5} profileImage="" isLoggedIn={false} />
           </div>
-          <div className="ml-1 w-[19.62rem] text-wall-street text-base cursor-pointer">
-            {nickname}
+          <div className="ml-2 w-[18rem] text-wall-street text-base">
+            <span className="text-sm cursor-pointer">{nickname}</span>
           </div>
           <div className="flex w-[1rem]">{active && <CloseButton mode="small" />}</div>
         </div>
-        <div className="flex items-center min-h-[2.4rem] p-1 text-base break-all">
+        <div className="flex items-center min-h-[2.4rem] py-3 text-base break-all">
           <span>{content}</span>
         </div>
-        <div className="w-[22.125rem] h-[1.125rem] text-wall-street text-sm">{timestamp}</div>
+        <div className="w-[20rem] h-[1.125rem] text-wall-street text-xs">{timestamp}</div>
+        <div className="w-[20rem] mt-[7%] border-b-[0.01rem] border-gray" />
       </div>
     </div>
   );

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -1,10 +1,10 @@
 import { useTabContext } from '@hooks/useTabContext';
 
-interface TabItemProps {
+type TabItemProps = {
   title: string;
   index: string;
   children: React.ReactNode;
-}
+};
 
 const TabItem = ({ index, children }: TabItemProps) => {
   const { activeTab } = useTabContext();

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -6,7 +6,7 @@ export const useArticleDetail = () => {
   const { data, isFetching } = useQuery<Post>(
     ['article'],
     async () => {
-      const response = await axiosClient.get('posts/65068d859fae952aa0cfbdcf');
+      const response = await axiosClient.get('posts/65069ea19fae952aa0cfbf9b');
       return response.data;
     },
     {

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
+import { axiosClient } from '@/api/axiosClient';
+import { Post } from '@/type/Post';
+
+export const useArticleDetail = () => {
+  const { data, isFetching } = useQuery<AxiosResponse<Post>>(
+    ['article'],
+    async () => {
+      const response = await axiosClient.get('posts/65069ea19fae952aa0cfbf9b');
+      return response;
+    },
+    {
+      staleTime: 1000 * 5,
+    },
+  );
+
+  return { data, isFetching };
+};

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -6,11 +6,12 @@ export const useArticleDetail = () => {
   const { data, isFetching } = useQuery<Post>(
     ['article'],
     async () => {
-      const response = await axiosClient.get('posts/65069ea19fae952aa0cfbf9b');
+      const response = await axiosClient.get('/posts/65069ea19fae952aa0cfbf9b');
       return response.data;
     },
     {
       staleTime: 1000 * 5,
+      cacheTime: 1000 * 5,
     },
   );
 

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -1,14 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
-import { AxiosResponse } from 'axios';
 import { axiosClient } from '@/api/axiosClient';
 import { Post } from '@/type/Post';
 
 export const useArticleDetail = () => {
-  const { data, isFetching } = useQuery<AxiosResponse<Post>>(
+  const { data, isFetching } = useQuery<Post>(
     ['article'],
     async () => {
       const response = await axiosClient.get('posts/65069ea19fae952aa0cfbf9b');
-      return response;
+      return response.data;
     },
     {
       staleTime: 1000 * 5,

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -1,12 +1,16 @@
+import { useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { axiosClient } from '@/api/axiosClient';
 import { Post } from '@/type/Post';
 
 export const useArticleDetail = () => {
+  const { pathname: url } = useLocation();
+  const postId = url.split('/').pop();
+
   const { data, isFetching } = useQuery<Post>(
     ['article'],
     async () => {
-      const response = await axiosClient.get('/posts/65069ea19fae952aa0cfbf9b');
+      const response = await axiosClient.get(`/posts/${postId}`);
       return response.data;
     },
     {

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -6,7 +6,7 @@ export const useArticleDetail = () => {
   const { data, isFetching } = useQuery<Post>(
     ['article'],
     async () => {
-      const response = await axiosClient.get('posts/65069ea19fae952aa0cfbf9b');
+      const response = await axiosClient.get('posts/65068d859fae952aa0cfbdcf');
       return response.data;
     },
     {

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -1,5 +1,15 @@
+// import { useArticleDetail } from '@/hooks/useArticleDetail';
+
 const ArticleDetailPage = () => {
-  return <h2>글 상세 페이지입니다</h2>;
+  // const { data, isFetching } = useArticleDetail();
+  // const article = data?.data;
+
+  // if (article) {
+  //   const { _id, title, body, author, createdAt, likes, image, comments } = article;
+  //   const { fullName } = author;
+  // }
+
+  return <h1>글 작성 페이지</h1>;
 };
 
 export default ArticleDetailPage;

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -3,11 +3,12 @@ import { FiEdit } from 'react-icons/fi';
 import ArticleDetail from '@/components/ArticleDetail';
 import ArticleInfoIcon from '@/components/ArticleInfoIcon';
 import BackButton from '@/components/BackButton';
+import Loader from '@/components/Loader';
 import SubButton from '@/components/SubButton';
 import { useArticleDetail } from '@/hooks/useArticleDetail';
 
 const ArticleDetailPage = () => {
-  const { data: article } = useArticleDetail();
+  const { data: article, isFetching } = useArticleDetail();
 
   const { title, author, createdAt, likes, image, comments } = article!;
   const { fullName } = author;
@@ -27,18 +28,24 @@ const ArticleDetailPage = () => {
             </button>
           </div>
         </div>
-        <div>
-          <ArticleDetail nickname={fullName} postedDate={createdAt} />
-          <div className="my-3 text-lg font-Cafe24Surround">{articleTitle}</div>
-          <div className="flex justify-center items-center">
-            {image && <img src={image} className="w-[10rem] m-5" />}
+        {isFetching ? (
+          <div className="flex justify-center">
+            <Loader />
           </div>
-          <div className="text-base">{articleBody}</div>
-          <div className="flex justify-between mt-6">
-            <SubButton label="응원하기" color="blue" type="outline" />
-            <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
+        ) : (
+          <div>
+            <ArticleDetail nickname={fullName} postedDate={createdAt} />
+            <div className="my-3 text-lg font-Cafe24Surround">{articleTitle}</div>
+            <div className="flex justify-center items-center">
+              {image && <img src={image} className="w-[10rem] m-5" />}
+            </div>
+            <div className="text-base">{articleBody}</div>
+            <div className="flex justify-between mt-6">
+              <SubButton label="응원하기" color="blue" type="outline" />
+              <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
+            </div>
           </div>
-        </div>
+        )}
         <div className="my-[10%] border-b-[0.01rem] border-lazy-gray" />
       </section>
     </div>

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -1,15 +1,48 @@
-// import { useArticleDetail } from '@/hooks/useArticleDetail';
+import { BsTrash } from 'react-icons/bs';
+import { FiEdit } from 'react-icons/fi';
+import ArticleDetail from '@/components/ArticleDetail';
+import ArticleInfoIcon from '@/components/ArticleInfoIcon';
+import BackButton from '@/components/BackButton';
+import SubButton from '@/components/SubButton';
+import { useArticleDetail } from '@/hooks/useArticleDetail';
 
 const ArticleDetailPage = () => {
-  // const { data, isFetching } = useArticleDetail();
-  // const article = data?.data;
+  const { data: article } = useArticleDetail();
 
-  // if (article) {
-  //   const { _id, title, body, author, createdAt, likes, image, comments } = article;
-  //   const { fullName } = author;
-  // }
+  const { title, author, createdAt, likes, image, comments } = article!;
+  const { fullName } = author;
+  const { title: articleTitle, body: articleBody } = JSON.parse(title);
 
-  return <h1>글 작성 페이지</h1>;
+  return (
+    <div className="flex flex-col items-center max-w-[25.875rem] mx-auto max-h-[56rem] h-full pt-[2.75rem] font-Cafe24SurroundAir">
+      <section className="post-field max-w-[22rem] w-full">
+        <div className="flex justify-between">
+          <BackButton />
+          <div id="isMine" className="flex items-center justify-between w-[2.5rem]">
+            <button type="button" name="edit">
+              <FiEdit className="w-[1rem] h-[1rem]" />
+            </button>
+            <button type="button" name="delete">
+              <BsTrash className="w-[1rem] h-[1rem]" />
+            </button>
+          </div>
+        </div>
+        <div>
+          <ArticleDetail nickname={fullName} postedDate={createdAt} />
+          <div className="my-3 text-lg font-Cafe24Surround">{articleTitle}</div>
+          <div className="flex justify-center items-center">
+            {image && <img src={image} className="w-[10rem] m-5" />}
+          </div>
+          <div className="text-base">{articleBody}</div>
+          <div className="flex justify-between mt-6">
+            <SubButton label="응원하기" color="blue" type="outline" />
+            <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
+          </div>
+        </div>
+        <div className="my-[10%] border-b-[0.01rem] border-lazy-gray" />
+      </section>
+    </div>
+  );
 };
 
 export default ArticleDetailPage;

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -16,23 +16,23 @@ const ArticleDetailPage = () => {
 
   return (
     <div className="flex flex-col items-center max-w-[25.875rem] mx-auto max-h-[56rem] h-full pt-[2.75rem] font-Cafe24SurroundAir">
-      <section className="post-field max-w-[22rem] w-full">
-        <div className="flex justify-between">
-          <BackButton />
-          <div id="isMine" className="flex items-center justify-between w-[2.5rem]">
-            <button type="button" name="edit">
-              <FiEdit className="w-[1rem] h-[1rem]" />
-            </button>
-            <button type="button" name="delete">
-              <BsTrash className="w-[1rem] h-[1rem]" />
-            </button>
-          </div>
+      {isFetching ? (
+        <div className="flex justify-center">
+          <Loader />
         </div>
-        {isFetching ? (
-          <div className="flex justify-center">
-            <Loader />
+      ) : (
+        <section className="post-field max-w-[22rem] w-full">
+          <div className="flex justify-between">
+            <BackButton />
+            <div id="isMine" className="flex items-center justify-between w-[2.5rem]">
+              <button type="button" name="edit">
+                <FiEdit className="w-[1rem] h-[1rem]" />
+              </button>
+              <button type="button" name="delete">
+                <BsTrash className="w-[1rem] h-[1rem]" />
+              </button>
+            </div>
           </div>
-        ) : (
           <div>
             <ArticleDetail nickname={fullName} postedDate={createdAt} />
             <div className="my-3 text-lg font-Cafe24Surround">{articleTitle}</div>
@@ -45,9 +45,9 @@ const ArticleDetailPage = () => {
               <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
             </div>
           </div>
-        )}
-        <div className="my-[10%] border-b-[0.01rem] border-lazy-gray" />
-      </section>
+          <div className="my-[10%] border-b-[0.01rem] border-lazy-gray" />
+        </section>
+      )}
     </div>
   );
 };

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -7,15 +7,20 @@ import BackButton from '@/components/BackButton';
 import Loader from '@/components/Loader';
 import SubButton from '@/components/SubButton';
 import { useArticleDetail } from '@/hooks/useArticleDetail';
+//import { useAuthContext } from '@/hooks/useAuthContext';
+import CommentInput from './ArticleDetailPage/CommentInput';
 import Comments from './ArticleDetailPage/Comments';
 
 const ArticleDetailPage = () => {
   const { data: article, isFetching } = useArticleDetail();
+  //const { user } = useAuthContext();
   const navigate = useNavigate();
 
   if (isFetching) {
     return <Loader />;
   }
+
+  //console.log(user);
 
   const { title, author, createdAt, likes, image, comments } = article!;
   const { fullName } = author;
@@ -59,6 +64,7 @@ const ArticleDetailPage = () => {
           <Comments comments={comments} />
         )}
       </section>
+      <CommentInput />
     </div>
   );
 };

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -6,6 +6,7 @@ import BackButton from '@/components/BackButton';
 import Loader from '@/components/Loader';
 import SubButton from '@/components/SubButton';
 import { useArticleDetail } from '@/hooks/useArticleDetail';
+import Comments from './ArticleDetailPage/Comments';
 
 const ArticleDetailPage = () => {
   const { data: article, isFetching } = useArticleDetail();
@@ -19,12 +20,12 @@ const ArticleDetailPage = () => {
   const { title: articleTitle, body: articleBody } = JSON.parse(title);
 
   return (
-    <div className="flex flex-col items-center max-w-[25.875rem] mx-auto max-h-[56rem] h-full pt-[2.75rem] font-Cafe24SurroundAir">
+    <div className="flex flex-col items-center max-w-[25.875rem] mx-auto h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir border-2">
       <div className="flex justify-center" />
       <section className="post-field max-w-[22rem] w-full">
         <div className="flex justify-between">
           <BackButton />
-          <div id="isMine" className="flex items-center justify-between w-[2.5rem]">
+          <div id="isMine" className="flex items-center justify-between w-[3rem]">
             <button type="button" name="edit">
               <FiEdit className="w-[1rem] h-[1rem]" />
             </button>
@@ -45,7 +46,16 @@ const ArticleDetailPage = () => {
             <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
           </div>
         </div>
-        <div className="my-[10%] border-b-[0.01rem] border-lazy-gray" />
+        <div className="mt-[10%] mb-[5%] border-b-[0.01rem] border-lazy-gray" />
+      </section>
+      <section>
+        {comments.length === 0 ? (
+          <div className="flex justify-start w-[22rem] mt-[3%]">
+            <span className="text-xs text-gray-400">댓글이 없습니다</span>
+          </div>
+        ) : (
+          <Comments comments={comments} />
+        )}
       </section>
     </div>
   );

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { BsTrash } from 'react-icons/bs';
 import { FiEdit } from 'react-icons/fi';
 import ArticleDetail from '@/components/ArticleDetail';
@@ -10,6 +11,7 @@ import Comments from './ArticleDetailPage/Comments';
 
 const ArticleDetailPage = () => {
   const { data: article, isFetching } = useArticleDetail();
+  const navigate = useNavigate();
 
   if (isFetching) {
     return <Loader />;
@@ -24,7 +26,7 @@ const ArticleDetailPage = () => {
       <div className="flex justify-center" />
       <section className="post-field max-w-[22rem] w-full">
         <div className="flex justify-between">
-          <BackButton />
+          <BackButton onClick={() => navigate(-1)} />
           <div id="isMine" className="flex items-center justify-between w-[3rem]">
             <button type="button" name="edit">
               <FiEdit className="w-[1rem] h-[1rem]" />
@@ -46,7 +48,7 @@ const ArticleDetailPage = () => {
             <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
           </div>
         </div>
-        <div className="mt-[10%] mb-[5%] border-b-[0.01rem] border-lazy-gray" />
+        <div className="banner mt-[10%] mb-[5%] border-b-[0.01rem] border-lazy-gray" />
       </section>
       <section>
         {comments.length === 0 ? (

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -7,24 +7,24 @@ import BackButton from '@/components/BackButton';
 import Loader from '@/components/Loader';
 import SubButton from '@/components/SubButton';
 import { useArticleDetail } from '@/hooks/useArticleDetail';
-//import { useAuthContext } from '@/hooks/useAuthContext';
+import { useAuthContext } from '@/hooks/useAuthContext';
 import CommentInput from './ArticleDetailPage/CommentInput';
 import Comments from './ArticleDetailPage/Comments';
 
 const ArticleDetailPage = () => {
   const { data: article, isFetching } = useArticleDetail();
-  //const { user } = useAuthContext();
+  const { user } = useAuthContext();
   const navigate = useNavigate();
 
   if (isFetching) {
     return <Loader />;
   }
 
-  //console.log(user);
-
   const { title, author, createdAt, likes, image, comments } = article!;
-  const { fullName } = author;
+  const { fullName, _id: postUserId } = author;
   const { title: articleTitle, body: articleBody } = JSON.parse(title);
+  const isMyPost = user ? user._id === postUserId : false;
+  const isLoginUser = user ? true : false;
 
   return (
     <div className="flex flex-col items-center max-w-[25.875rem] mx-auto h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir border-2">
@@ -32,14 +32,17 @@ const ArticleDetailPage = () => {
       <section className="post-field max-w-[22rem] w-full">
         <div className="flex justify-between">
           <BackButton onClick={() => navigate(-1)} />
-          <div id="isMine" className="flex items-center justify-between w-[3rem]">
-            <button type="button" name="edit">
-              <FiEdit className="w-[1rem] h-[1rem]" />
-            </button>
-            <button type="button" name="delete">
-              <BsTrash className="w-[1rem] h-[1rem]" />
-            </button>
-          </div>
+          <div />
+          {isMyPost && (
+            <div id="isMine" className="flex items-center justify-between w-[3rem]">
+              <button type="button" name="edit">
+                <FiEdit className="w-[1rem] h-[1rem]" />
+              </button>
+              <button type="button" name="delete">
+                <BsTrash className="w-[1rem] h-[1rem]" />
+              </button>
+            </div>
+          )}
         </div>
         <div>
           <ArticleDetail nickname={fullName} postedDate={createdAt} />
@@ -64,7 +67,7 @@ const ArticleDetailPage = () => {
           <Comments comments={comments} />
         )}
       </section>
-      <CommentInput />
+      {isLoginUser && <CommentInput />}
     </div>
   );
 };

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -10,44 +10,43 @@ import { useArticleDetail } from '@/hooks/useArticleDetail';
 const ArticleDetailPage = () => {
   const { data: article, isFetching } = useArticleDetail();
 
+  if (isFetching) {
+    return <Loader />;
+  }
+
   const { title, author, createdAt, likes, image, comments } = article!;
   const { fullName } = author;
   const { title: articleTitle, body: articleBody } = JSON.parse(title);
 
   return (
     <div className="flex flex-col items-center max-w-[25.875rem] mx-auto max-h-[56rem] h-full pt-[2.75rem] font-Cafe24SurroundAir">
-      {isFetching ? (
-        <div className="flex justify-center">
-          <Loader />
+      <div className="flex justify-center" />
+      <section className="post-field max-w-[22rem] w-full">
+        <div className="flex justify-between">
+          <BackButton />
+          <div id="isMine" className="flex items-center justify-between w-[2.5rem]">
+            <button type="button" name="edit">
+              <FiEdit className="w-[1rem] h-[1rem]" />
+            </button>
+            <button type="button" name="delete">
+              <BsTrash className="w-[1rem] h-[1rem]" />
+            </button>
+          </div>
         </div>
-      ) : (
-        <section className="post-field max-w-[22rem] w-full">
-          <div className="flex justify-between">
-            <BackButton />
-            <div id="isMine" className="flex items-center justify-between w-[2.5rem]">
-              <button type="button" name="edit">
-                <FiEdit className="w-[1rem] h-[1rem]" />
-              </button>
-              <button type="button" name="delete">
-                <BsTrash className="w-[1rem] h-[1rem]" />
-              </button>
-            </div>
+        <div>
+          <ArticleDetail nickname={fullName} postedDate={createdAt} />
+          <div className="my-3 text-lg font-Cafe24Surround">{articleTitle}</div>
+          <div className="flex justify-center items-center">
+            {image && <img src={image} className="w-[10rem] m-5" />}
           </div>
-          <div>
-            <ArticleDetail nickname={fullName} postedDate={createdAt} />
-            <div className="my-3 text-lg font-Cafe24Surround">{articleTitle}</div>
-            <div className="flex justify-center items-center">
-              {image && <img src={image} className="w-[10rem] m-5" />}
-            </div>
-            <div className="text-base">{articleBody}</div>
-            <div className="flex justify-between mt-6">
-              <SubButton label="응원하기" color="blue" type="outline" />
-              <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
-            </div>
+          <div className="text-base">{articleBody}</div>
+          <div className="flex justify-between mt-6">
+            <SubButton label="응원하기" color="blue" type="outline" />
+            <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
           </div>
-          <div className="my-[10%] border-b-[0.01rem] border-lazy-gray" />
-        </section>
-      )}
+        </div>
+        <div className="my-[10%] border-b-[0.01rem] border-lazy-gray" />
+      </section>
     </div>
   );
 };

--- a/src/pages/ArticleDetailPage/CommentInput.tsx
+++ b/src/pages/ArticleDetailPage/CommentInput.tsx
@@ -1,0 +1,59 @@
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { RiQuillPenFill } from 'react-icons/ri';
+import Avatar from '@/components/Avatar';
+
+type FormValueType = {
+  comment: string;
+};
+
+const CommentInput = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValueType>();
+
+  const onSubmit: SubmitHandler<FormValueType> = (data) => {
+    try {
+      alert(JSON.stringify(data));
+    } catch (error) {
+      alert(error);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-2 flex justify-center items-center max-w-[24.875rem] w-full max-h-[3.75rem] h-full rounded-2xl bg-[#EEF1F4] font-Cafe24SurroundAir">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div className="flex justify-between w-[23rem]">
+          <div className="flex justify-center items-center">
+            <Avatar width={1.5} profileImage="" isLoggedIn={false} />
+          </div>
+          <div className="flex justify-center items-center">
+            <input
+              {...register('comment', {
+                required: '댓글을 작성해주세요',
+                maxLength: {
+                  value: 200,
+                  message: '200자 이내로 입력해주세요',
+                },
+              })}
+              className="w-[18rem] bg-[#EEF1F4] outline-none"
+              placeholder="댓글을 작성해주세요."
+              maxLength={200}
+            />
+          </div>
+          <div className="flex justify-center items-center">
+            <button className="outline-none cursor-pointer">
+              <RiQuillPenFill className="fill-cooled-blue w-[1.5rem] h-[1.5rem]" />
+            </button>
+          </div>
+        </div>
+        {errors?.comment && (
+          <span className="text-xs text-error-red">{errors.comment.message}</span>
+        )}
+      </form>
+    </div>
+  );
+};
+
+export default CommentInput;

--- a/src/pages/ArticleDetailPage/Comments.tsx
+++ b/src/pages/ArticleDetailPage/Comments.tsx
@@ -1,0 +1,29 @@
+import Comment from '@/components/Comment';
+import { Comment as CommentType } from '@/type/Comment';
+
+type CommentsProps = {
+  comments: CommentType[];
+};
+
+const Comments = ({ comments }: CommentsProps) => {
+  return comments?.map((comment_post) => {
+    const { _id, comment, author, createdAt } = comment_post;
+    const { fullName } = author;
+
+    try {
+      return (
+        <Comment
+          key={_id}
+          content={comment}
+          postedDate={createdAt}
+          nickname={fullName}
+          active={false}
+        />
+      );
+    } catch (error) {
+      alert(error);
+    }
+  });
+};
+
+export default Comments;

--- a/src/stories/ArticleDetail.stories.tsx
+++ b/src/stories/ArticleDetail.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ArticleDetail from '@/components/ArticleDetail';
+
+const meta = {
+  title: 'ArticleDetail',
+  component: ArticleDetail,
+  tags: ['autodocs'],
+  argTypes: {
+    nickname: { control: 'text' },
+    postedDate: { control: 'text' },
+  },
+  args: {
+    nickname: '@khakhiD',
+    postedDate: '2023-08-29T09:28:39.390Z',
+  },
+} as Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/utils/getTimeStamp.ts
+++ b/src/utils/getTimeStamp.ts
@@ -1,0 +1,11 @@
+export const getTimeStamp = (postedDate: string) => {
+  const dt = new Date(postedDate);
+  const [year, month, date, hours, minutes] = [
+    dt.getFullYear().toString().slice(-2),
+    dt.getMonth() + 1,
+    dt.getDate(),
+    dt.getHours(),
+    dt.getMinutes(),
+  ];
+  return `${year}/${month}/${date} ${hours}:${minutes}`;
+};


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #108 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 글 상세 페이지 레이아웃을 구현했습니다. 
- 게시판에서 특정 게시글을 선택 시, 해당 게시글의 상세 페이지로 이동합니다. 
- 자신이 작성한 게시글이 아닐 경우 수정, 삭제 버튼이 보이지 않습니다.
- 
## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/98521882/2018b1c3-6216-40a3-b1fd-ff161a791d5a)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

