### PR TITLE
feat: 뜨거운/구독한 탭 기능 구현

### DIFF
--- a/src/api/common/Post.ts
+++ b/src/api/common/Post.ts
@@ -1,12 +1,12 @@
 import type { Post } from '@/type/Post';
 import { axiosClient } from '../axiosClient';
 
-type InfinitiyScrollParams = {
+type InfinityScrollParams = {
   offset: number;
   limit: number;
 };
 
-export const fetchAllPosts = async ({ offset, limit }: Partial<InfinitiyScrollParams>) => {
+export const fetchAllPosts = async ({ offset, limit }: Partial<InfinityScrollParams>) => {
   const FETCH_ALL_POSTS_URL = '/posts/channel/64fac2e729260903240d2dab';
 
   const { data } = await axiosClient.get<Post[]>(FETCH_ALL_POSTS_URL, {
@@ -19,7 +19,7 @@ export const fetchUserPosts = async ({
   offset,
   limit,
   authorId,
-}: Partial<InfinitiyScrollParams> & { authorId: string }) => {
+}: Partial<InfinityScrollParams> & { authorId: string }) => {
   const FETCH_USER_POSTS_URL = `/posts/author/${authorId}`;
 
   const { data } = await axiosClient.get<Post[]>(FETCH_USER_POSTS_URL, {

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -11,18 +11,21 @@ type TabItemProps = {
 type TabProps = {
   active?: string;
   maxWidth: string;
+  defaultTab?: string;
   tabItems: TabItemProps[];
 };
 
-const Tab = ({ active, maxWidth, tabItems }: TabProps) => {
+const Tab = ({ active, maxWidth, defaultTab, tabItems }: TabProps) => {
   const { activeTab, setActiveTab } = useTabContext();
   const activeIndex = Number(activeTab.slice(-1)) - 1;
 
   useEffect(() => {
     if (active) {
       setActiveTab(active);
+    } else if (defaultTab) {
+      setActiveTab(defaultTab);
     }
-  }, [active, setActiveTab]);
+  }, [active, setActiveTab, defaultTab]);
 
   return (
     <div className="flex" style={{ maxWidth: `${maxWidth}rem` }}>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,16 +1,17 @@
 import React, { useEffect } from 'react';
 import { useTabContext } from '@hooks/useTabContext';
 
-type TabItem = {
+type TabItemProps = {
   title: string;
   width: string;
   icon?: React.ReactNode;
+  onClick?: () => void;
 };
 
 type TabProps = {
   active?: string;
   maxWidth: string;
-  tabItems: TabItem[];
+  tabItems: TabItemProps[];
 };
 
 const Tab = ({ active, maxWidth, tabItems }: TabProps) => {
@@ -32,7 +33,10 @@ const Tab = ({ active, maxWidth, tabItems }: TabProps) => {
           className={`font-Cafe24Surround cursor-pointer flex items-center justify-center h-[2.5rem] text-[1.125rem] border-b-2 ${
             activeIndex === index ? 'text-cooled-blue border-cooled-blue' : 'text-lazy-gray'
           }`}
-          onClick={() => setActiveTab(`item${index + 1}`)}
+          onClick={() => {
+            tabItem.onClick?.();
+            setActiveTab(`item${index + 1}`);
+          }}
         >
           <span className={`${activeIndex === index ? 'text-cooled-blue' : 'text-lazy-gray'}`}>
             {tabItem.icon}

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -1,7 +1,6 @@
 import { useTabContext } from '@hooks/useTabContext';
 
 type TabItemProps = {
-  title: string;
   index: string;
   children: React.ReactNode;
 };

--- a/src/constants/Article.ts
+++ b/src/constants/Article.ts
@@ -1,6 +1,7 @@
 export const API = {
   ARTICLES_URL: '/posts',
   AUTHOR_URL: '/author',
+  SEARCH_URL: '/search',
   CHANNEL_URL: '/channel',
   CHANNEL_ID: '64fac2e729260903240d2dab',
 };

--- a/src/constants/Article.ts
+++ b/src/constants/Article.ts
@@ -12,3 +12,4 @@ export const ROUTES = {
 export const HOTTEST_ARTICLE_LIKES_THRESHOLD = 15;
 export const ARTICLE_TITLE_MAX_LENGTH = 20;
 export const ARTICLE_BODY_MAX_LENGTH = 500;
+export const ARTICLE_FETCH_LIMIT = 10;

--- a/src/context/TabContext.tsx
+++ b/src/context/TabContext.tsx
@@ -11,7 +11,7 @@ const TabContext = createContext<TabContextProps>({
 });
 
 export const TabContextProvider = ({ children }: { children: React.ReactNode }) => {
-  const [activeTab, setActiveTab] = useState('item1');
+  const [activeTab, setActiveTab] = useState('');
 
   return <TabContext.Provider value={{ activeTab, setActiveTab }}>{children}</TabContext.Provider>;
 };

--- a/src/hooks/useFilteredArticles.tsx
+++ b/src/hooks/useFilteredArticles.tsx
@@ -7,10 +7,6 @@ export const useFilteredArticles = (tabFilter: TabConstants, articles: Post[]) =
   return useMemo(() => {
     if (tabFilter === TabConstants.HOTTEST) {
       return articles?.filter((article) => article.likes.length >= HOTTEST_ARTICLE_LIKES_THRESHOLD);
-    } else if (tabFilter === TabConstants.SUBSCRIBED) {
-      // TODO: 현재 사용자의 정보가 있어야 한다. (User 타입의 following)
-      // undefined를 반환하지 않도록 임시로 articles 반환.
-      return articles;
     } else {
       return articles;
     }

--- a/src/hooks/useScrollToTop.tsx
+++ b/src/hooks/useScrollToTop.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 const useScrollToTop = () => {
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLElement>(null);
   const [showScrollToTopButton, setShowScrollToTopButton] = useState(false);
 
   const scrollToTop = () => {

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -47,7 +47,7 @@ const ArticleDetailPage = () => {
         <div>
           <ArticleDetail nickname={fullName} postedDate={createdAt} />
           <div className="my-3 text-lg font-Cafe24Surround">{articleTitle}</div>
-          <div className="flex justify-center items-center">
+          <div className="flex items-center justify-center">
             {image && <img src={image} className="w-[10rem] m-5" />}
           </div>
           <div className="text-base">{articleBody}</div>

--- a/src/pages/ArticlesPage/Articles.tsx
+++ b/src/pages/ArticlesPage/Articles.tsx
@@ -1,4 +1,7 @@
+import { useNavigate } from 'react-router-dom';
 import { Post } from '@type/Post';
+import SubButton from '@/components/SubButton';
+import { API } from '@/constants/Article';
 import Article from '@components/Article';
 
 type ArticlesProps = {
@@ -6,6 +9,25 @@ type ArticlesProps = {
 };
 
 const Articles = ({ articles }: ArticlesProps) => {
+  const navigate = useNavigate();
+  const isArticlesEmpty = articles && articles.length === 0;
+
+  if (isArticlesEmpty) {
+    return (
+      <div className="flex flex-col justify-center w-full gap-4 mx-auto mt-4">
+        <span className="text-center">앗, 팔로우한 사람들의 글 목록이 존재하지 않습니다!</span>
+        <div
+          className="inline-block mx-auto"
+          onClick={() => {
+            navigate(`${API.SEARCH_URL}`);
+          }}
+        >
+          <SubButton size="small" color="blue" label="팔로우 하러 가기" type="outline" />
+        </div>
+      </div>
+    );
+  }
+
   return articles?.map((article) => {
     const { _id, title, author, createdAt, likes, image, comments } = article;
     const { fullName } = author;
@@ -23,8 +45,8 @@ const Articles = ({ articles }: ArticlesProps) => {
           comments={comments?.length || 0}
         />
       );
-    } catch (error) {
-      // TODO: title의 JSON.stringify가 제대로 되지 않은 경우 어떻게 처리할까...
+    } catch (e) {
+      // title에 JSON.parse가 안되는게 존재하면 에러남.
     }
   });
 };

--- a/src/pages/ArticlesPage/InfiniteScroll.tsx
+++ b/src/pages/ArticlesPage/InfiniteScroll.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+
+type InfiniteScrollProps = {
+  fetchData: () => void;
+  canFetchMore: boolean | undefined;
+};
+
+const InfiniteScroll = ({ fetchData, canFetchMore }: InfiniteScrollProps) => {
+  const observerRef = useRef(null);
+
+  useEffect(() => {
+    const handleObserver = (entries: IntersectionObserverEntry[]) => {
+      const target = entries[0];
+      if (target.isIntersecting && canFetchMore) {
+        fetchData();
+      }
+    };
+
+    const observer = new IntersectionObserver(handleObserver, {
+      root: null,
+      rootMargin: '0px',
+      threshold: 1.0,
+    });
+
+    if (observerRef.current) {
+      observer.observe(observerRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [fetchData, canFetchMore]);
+
+  return <div ref={observerRef} />;
+};
+
+export default InfiniteScroll;

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -98,6 +98,7 @@ const ProfilePage = () => {
           </div>
           <Tab
             maxWidth="25.875"
+            defaultTab="item1"
             tabItems={[
               { title: '작성한 기사', width: '12.9375' },
               { title: '응원한 기사', width: '12.9375' },
@@ -105,7 +106,7 @@ const ProfilePage = () => {
           />
         </header>
         <article ref={ref} className="flex-grow overflow-y-auto">
-          <TabItem title="작성한 기사" index="item1">
+          <TabItem index="item1">
             {isFetching && (
               <div className="flex items-center justify-center">
                 <Loader />
@@ -119,7 +120,7 @@ const ProfilePage = () => {
               </div>
             )}
           </TabItem>
-          <TabItem title="응원한 기사" index="item2">
+          <TabItem index="item2">
             {isFetching && (
               <div className="flex items-center justify-center">
                 <Loader />

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -89,7 +89,7 @@ const ProfilePage = () => {
               </div>
               <SubscribeInfo
                 subscriber={currentProfileUser ? currentProfileUser.followers.length : 0}
-                subscribing={currentProfileUser ? currentProfileUser.comments.length : 0}
+                subscribing={currentProfileUser ? currentProfileUser.following.length : 0}
               />
               <span className="text-center px-[2.8rem] mt-[1rem]">
                 {currentProfileUser ? currentProfileUser.username : '자기소개가 없습니다.'}

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -8,7 +8,7 @@ import SubButton from '@components/SubButton';
 import Tab from '@components/Tab';
 import TabItem from '@components/TabItem';
 import { DEBOUNCE_TIME, MINIMUM__DATA } from '@constants/Search';
-import { TabConstants } from '@constants/Tab';
+import { TAB_CONSTANTS } from '@constants/Tab';
 import { TabContextProvider } from '@context/TabContext';
 import useDebounceValue from '@hooks/useDebounce';
 import useRecentResult from '@hooks/useRecentResult';
@@ -36,7 +36,7 @@ const SearchPage = () => {
           </div>
           <div className="flex justify-center">
             <div className="bg-white w-[23.375rem] rounded-lg">
-              <form className="flex relative items-center ">
+              <form className="relative flex items-center ">
                 <MdOutlineSearch className="w-[1.8rem] h-[1.8rem] cursor-pointer absolute left-4" />
                 <input
                   className={INPUT_CLASS}
@@ -51,8 +51,8 @@ const SearchPage = () => {
                 <Tab
                   maxWidth="23.375"
                   tabItems={[
-                    { title: `${TabConstants.ARTICLE_TITLE}`, width: '11.6875' },
-                    { title: `${TabConstants.NICKNAME}`, width: '11.6875' },
+                    { title: `${TAB_CONSTANTS.ARTICLE_TITLE}`, width: '11.6875' },
+                    { title: `${TAB_CONSTANTS.NICKNAME}`, width: '11.6875' },
                   ]}
                 />
               </div>
@@ -60,14 +60,14 @@ const SearchPage = () => {
           </div>
         </header>
         <article className="flex-grow gap-4 overflow-y-auto pb-[4.75rem]">
-          <TabItem title={`${TabConstants.ARTICLE_TITLE}`} index="item1">
+          <TabItem title={`${TAB_CONSTANTS.ARTICLE_TITLE}`} index="item1">
             {isFetching ? (
               <SearchSkeleton SkeletonType={'title'} />
             ) : (
               <SearchResultList data={data} />
             )}
           </TabItem>
-          <TabItem title={`${TabConstants.SUBSCRIBED}`} index="item2">
+          <TabItem title={`${TAB_CONSTANTS.SUBSCRIBED}`} index="item2">
             {isFetching ? (
               <SearchSkeleton SkeletonType={'user'} />
             ) : (
@@ -79,7 +79,7 @@ const SearchPage = () => {
           <footer className="mb-8">
             <h2 className="font-Cafe24Surround text-[1.125rem]">최근 검색어</h2>
             <hr className="mt-2 mb-5" />
-            <div className="flex gap-2 flex-wrap">
+            <div className="flex flex-wrap gap-2">
               {recentResult.map((item, index) => (
                 <div key={index}>
                   <SubButton

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -50,6 +50,7 @@ const SearchPage = () => {
               <div className="pt-[1.63rem]">
                 <Tab
                   maxWidth="23.375"
+                  defaultTab="item1"
                   tabItems={[
                     { title: `${TAB_CONSTANTS.ARTICLE_TITLE}`, width: '11.6875' },
                     { title: `${TAB_CONSTANTS.NICKNAME}`, width: '11.6875' },
@@ -60,14 +61,14 @@ const SearchPage = () => {
           </div>
         </header>
         <article className="flex-grow gap-4 overflow-y-auto pb-[4.75rem]">
-          <TabItem title={`${TAB_CONSTANTS.ARTICLE_TITLE}`} index="item1">
+          <TabItem index="item1">
             {isFetching ? (
               <SearchSkeleton SkeletonType={'title'} />
             ) : (
               <SearchResultList data={data} />
             )}
           </TabItem>
-          <TabItem title={`${TAB_CONSTANTS.SUBSCRIBED}`} index="item2">
+          <TabItem index="item2">
             {isFetching ? (
               <SearchSkeleton SkeletonType={'user'} />
             ) : (

--- a/src/stories/Tab.stories.tsx
+++ b/src/stories/Tab.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => {
       <TabContextProvider>
         <Tab
           maxWidth="25.875"
+          defaultTab="item1"
           tabItems={[
             { title: `${TAB_CONSTANTS.NEWEST}`, width: '8.625' },
             {
@@ -36,10 +37,10 @@ export const Default = () => {
             },
           ]}
         />
-        <TabItem title={`${TAB_CONSTANTS.NEWEST}`} index="item1">
+        <TabItem index="item1">
           <Loader />
         </TabItem>
-        <TabItem title={`${TAB_CONSTANTS.HOTTEST}`} index="item2">
+        <TabItem index="item2">
           <Article
             id="1"
             title="(임시)이거슨 뜨겁다."
@@ -50,7 +51,7 @@ export const Default = () => {
             comments={42}
           />
         </TabItem>
-        <TabItem title={`${TAB_CONSTANTS.SUBSCRIBED}`} index="item3">
+        <TabItem index="item3">
           <Article
             id="1"
             title="(임시)이거슨 구독이다."
@@ -72,15 +73,16 @@ export const TitleAndNicknameTab = () => {
       <TabContextProvider>
         <Tab
           maxWidth="23.375"
+          defaultTab="item1"
           tabItems={[
             { title: `${TAB_CONSTANTS.ARTICLE_TITLE}`, width: '11.6875' },
             { title: `${TAB_CONSTANTS.NICKNAME}`, width: '11.6875' },
           ]}
         />
-        <TabItem title={`${TAB_CONSTANTS.NEWEST}`} index="item1">
+        <TabItem index="item1">
           <Loader />
         </TabItem>
-        <TabItem title={`${TAB_CONSTANTS.SUBSCRIBED}`} index="item2">
+        <TabItem index="item2">
           <ErrorText text="아직 구독한 사용자가 없습니다." />
         </TabItem>
       </TabContextProvider>
@@ -94,15 +96,16 @@ export const SubscribeTab = () => {
       <TabContextProvider>
         <Tab
           maxWidth="23.375"
+          defaultTab="item1"
           tabItems={[
             { title: `${TAB_CONSTANTS.SUBSCRIBER}`, width: '11.6875' },
             { title: `${TAB_CONSTANTS.SUBSCRIBING}`, width: '11.6875' },
           ]}
         />
-        <TabItem title={`${TAB_CONSTANTS.SUBSCRIBER}`} index="item1">
+        <TabItem index="item1">
           <Loader />
         </TabItem>
-        <TabItem title={`${TAB_CONSTANTS.SUBSCRIBING}`} index="item2">
+        <TabItem index="item2">
           <Article
             id="1"
             title="(임시)이거슨 구독이다."


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #139 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
1. 뜨거운/구독한 탭 기능을 구현했습니다.
2. 현재 클릭한 탭을 기억하는 기능을 추가했습니다.

- useInfiniteQuery를 사용해서 구독한 탭의 글들은 무한 스크롤로 가져오도록 구현했습니다.
- localStorage를 사용해서 현재 클릭한 탭을 저장합니다.
## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

![ezgif com-video-to-gif (9)](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43228743/5280e74b-7592-46dd-aab6-fd45414d847e)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

