### PR TITLE
feat: 글 상세 페이지 구현

### DIFF
--- a/src/api/common/Comment.ts
+++ b/src/api/common/Comment.ts
@@ -1,7 +1,7 @@
 import { Comment } from '@/type/Comment';
 import { axiosClient } from '../axiosClient';
 
-type CommentParams = {
+export type CommentParams = {
   comment: string;
   postId: string;
 };

--- a/src/api/common/Like.ts
+++ b/src/api/common/Like.ts
@@ -7,11 +7,11 @@ export const likePost = async (postId: string) => {
   return data;
 };
 
-export const deleteLikePost = async (postId: string) => {
+export const deleteLikePost = async (id: string) => {
   const LIKE_POST_URL = '/likes/delete';
   const { data } = await axiosClient.delete<Like>(LIKE_POST_URL, {
     data: {
-      postId,
+      id,
     },
   });
   return data;

--- a/src/api/common/Post.ts
+++ b/src/api/common/Post.ts
@@ -96,21 +96,10 @@ export const updatePost = async ({
 
 export const deletePost = async (id: string) => {
   const DELETE_POST_URL = '/posts/delete';
-
-  try {
-    const response = await axiosClient.delete(DELETE_POST_URL, {
-      data: {
-        id,
-      },
-    });
-
-    if (response.status === 200) {
-      return true;
-    } else {
-      return false;
-    }
-  } catch (error) {
-    alert(error);
-    return false;
-  }
+  const response = await axiosClient.delete(DELETE_POST_URL, {
+    data: {
+      id,
+    },
+  });
+  return response;
 };

--- a/src/api/common/Post.ts
+++ b/src/api/common/Post.ts
@@ -97,9 +97,20 @@ export const updatePost = async ({
 export const deletePost = async (id: string) => {
   const DELETE_POST_URL = '/posts/delete';
 
-  return await axiosClient.delete(DELETE_POST_URL, {
-    data: {
-      id,
-    },
-  });
+  try {
+    const response = await axiosClient.delete(DELETE_POST_URL, {
+      data: {
+        id,
+      },
+    });
+
+    if (response.status === 200) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    alert(error);
+    return false;
+  }
 };

--- a/src/api/saveArticle.ts
+++ b/src/api/saveArticle.ts
@@ -1,8 +1,6 @@
 import { axiosClient } from './axiosClient';
 
 const CHANNEL_ID = '64fac2e729260903240d2dab';
-const TOKEN =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7Il9pZCI6IjY1MDU0MzhmOWZhZTk1MmFhMGNmYjViOSIsImVtYWlsIjoiY3l0ZXN0QG5hdmVyLmNvbSJ9LCJpYXQiOjE2OTQ4NDM3OTF9.K0yj-8NtLbEeE9rzKz7Yutbvndc__n8rjLHF1pw_rh4';
 
 type FormValue = {
   title: string;
@@ -21,7 +19,6 @@ export const saveArticle = async ({ title, body, image }: FormValue) => {
   await axiosClient.post('/posts/create', formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
-      Authorization: `bearer ${TOKEN}`,
     },
   });
 };

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -14,7 +14,12 @@ const ModeClasses = {
 
 const CloseButton = ({ mode = 'large', onClick, ...props }: CloseButtonProps) => {
   return (
-    <button className={`${BASE_BUTTON_CLASSES} ${ModeClasses[mode]}`} onClick={onClick} {...props}>
+    <button
+      type="button"
+      className={`${BASE_BUTTON_CLASSES} ${ModeClasses[mode]}`}
+      onClick={onClick}
+      {...props}
+    >
       <AiOutlineClose className={`icon ${ModeClasses[mode]}`} />
     </button>
   );

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -15,7 +15,7 @@ const Comment = ({ commentId, nickname, content, postedDate, active, onDelete }:
   const timestamp = getTimeStamp(postedDate);
 
   return (
-    <div className="flex justify-center items-center w-[20rem] min-h-[6rem] mt-3">
+    <div className="flex justify-center items-center w-[20rem] min-h-[6rem] mt-3 text-tricorn-black">
       <div className="flex flex-col w-[20rem]  font-Cafe24SurroundAir">
         <div className="flex w-[20rem] h-[1.5rem]">
           <div className="icon cursor-pointer">

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -3,13 +3,15 @@ import Avatar from './Avatar';
 import CloseButton from './CloseButton';
 
 type CommentProps = {
+  commentId: string;
   nickname: string;
   content: string;
   postedDate: string;
   active: boolean;
+  onDelete: (commentId: string) => void;
 };
 
-const Comment = ({ nickname, content, postedDate, active }: CommentProps) => {
+const Comment = ({ commentId, nickname, content, postedDate, active, onDelete }: CommentProps) => {
   const timestamp = getTimeStamp(postedDate);
 
   return (
@@ -22,7 +24,9 @@ const Comment = ({ nickname, content, postedDate, active }: CommentProps) => {
           <div className="ml-2 w-[18rem] text-wall-street text-base">
             <span className="text-sm cursor-pointer">{nickname}</span>
           </div>
-          <div className="flex w-[1rem]">{active && <CloseButton mode="small" />}</div>
+          <div className="flex w-[1rem]">
+            {active && <CloseButton mode="small" onClick={() => onDelete(commentId)} />}
+          </div>
         </div>
         <div className="flex items-center min-h-[2.4rem] py-3 text-base break-all">
           <span>{content}</span>

--- a/src/components/SubButton.tsx
+++ b/src/components/SubButton.tsx
@@ -5,6 +5,7 @@ type SubButtonProps = {
   size?: 'small' | 'medium' | 'large';
   type: 'fill' | 'outline';
   label: string;
+  onClick?: () => void;
 };
 
 const OUTLINE_TYPE = {

--- a/src/hooks/useArticle.tsx
+++ b/src/hooks/useArticle.tsx
@@ -1,12 +1,15 @@
+import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { saveArticle } from '@api/saveArticle';
 
 export const useArticle = () => {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   return useMutation(saveArticle, {
     onSuccess: () => {
       queryClient.invalidateQueries(['search']);
+      navigate('/news');
     },
   });
 };

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -9,7 +9,7 @@ export const useArticleDetail = () => {
   const { pathname: url } = useLocation();
   const postId = url.split('/').pop() || '';
 
-  const { data, isFetching } = useQuery<Post>(
+  const { data, isLoading } = useQuery<Post>(
     ['article', postId],
     async () => {
       const response = await fetchPost(postId);
@@ -30,5 +30,5 @@ export const useArticleDetail = () => {
     commentMutation.mutate({ ...newComment, postId });
   };
 
-  return { data, isFetching, addComment };
+  return { data, isLoading, addComment };
 };

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -15,7 +15,6 @@ export const useArticleDetail = () => {
     },
     {
       staleTime: 1000 * 5,
-      cacheTime: 1000 * 5,
     },
   );
 

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -8,7 +8,7 @@ export const useArticleDetail = () => {
   const postId = url.split('/').pop();
 
   const { data, isFetching } = useQuery<Post>(
-    ['article'],
+    ['article', postId],
     async () => {
       const response = await axiosClient.get(`/posts/${postId}`);
       return response.data;

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -67,7 +67,6 @@ const ArticleDetailPage = () => {
 
   return (
     <div className="flex flex-col items-center max-w-[25.875rem] mx-auto mb-9 h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir text-tricorn-black border-2">
-      <div className="flex justify-center" />
       <section className="post-field max-w-[22rem] w-full">
         <div className="flex justify-between">
           <BackButton onClick={() => navigate(-1)} />

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -15,21 +15,20 @@ import CommentInput from './ArticleDetailPage/CommentInput';
 import Comments from './ArticleDetailPage/Comments';
 
 const ArticleDetailPage = () => {
-  const { data: article, isFetching, addComment } = useArticleDetail();
+  const { data: article, isLoading, addComment } = useArticleDetail();
   const { user } = useAuthContext();
   const navigate = useNavigate();
   const [likePushed, setLikePushed] = useState(false);
   const [likesCount, setLikesCount] = useState(article?.likes.length);
 
   useEffect(() => {
-    // user가 로드되었을 때 isPostLiked 설정
     if (user) {
       const isPostLiked = user.likes.some((like) => like.post === article?._id);
       setLikePushed(isPostLiked);
     }
   }, [user, article]);
 
-  if (isFetching) {
+  if (isLoading) {
     return <Loader />;
   }
 

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -14,7 +14,7 @@ import CommentInput from './ArticleDetailPage/CommentInput';
 import Comments from './ArticleDetailPage/Comments';
 
 const ArticleDetailPage = () => {
-  const { data: article, isFetching } = useArticleDetail();
+  const { data: article, isFetching, addComment } = useArticleDetail();
   const { user } = useAuthContext();
   const navigate = useNavigate();
   const [likePushed, setLikePushed] = useState(false);
@@ -73,7 +73,7 @@ const ArticleDetailPage = () => {
         <div>
           <ArticleDetail nickname={fullName} postedDate={createdAt} />
           <div className="my-3 text-lg font-Cafe24Surround">{articleTitle}</div>
-          <div className="flex justify-center items-center">
+          <div className="flex items-center justify-center">
             {image && <img src={image} className="w-[10rem] m-5" />}
           </div>
           <div className="text-base">{articleBody}</div>
@@ -102,7 +102,7 @@ const ArticleDetailPage = () => {
           <Comments comments={comments} />
         )}
       </section>
-      {isLoginUser && <CommentInput postId={_id} />}
+      {isLoginUser && <CommentInput onAddComment={addComment} postId={_id} />}
     </div>
   );
 };

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BsTrash } from 'react-icons/bs';
 import { FiEdit } from 'react-icons/fi';
+import { deleteLikePost, likePost } from '@/api/common/Like';
 import ArticleDetail from '@components/ArticleDetail';
 import ArticleInfoIcon from '@components/ArticleInfoIcon';
 import BackButton from '@components/BackButton';
@@ -15,16 +17,22 @@ const ArticleDetailPage = () => {
   const { data: article, isFetching } = useArticleDetail();
   const { user } = useAuthContext();
   const navigate = useNavigate();
+  const [likePushed, setLikePushed] = useState(false);
 
   if (isFetching) {
     return <Loader />;
   }
 
-  const { title, author, createdAt, likes, image, comments } = article!;
+  const { _id, title, author, createdAt, likes, image, comments } = article!;
   const { fullName, _id: postUserId } = author;
   const { title: articleTitle, body: articleBody } = JSON.parse(title);
   const isMyPost = user ? user._id === postUserId : false;
   const isLoginUser = user ? true : false;
+
+  const handleLikePost = () => {
+    likePushed ? deleteLikePost(_id) : likePost(_id);
+    setLikePushed((prevLikePushed) => !prevLikePushed);
+  };
 
   return (
     <div className="flex flex-col items-center max-w-[25.875rem] mx-auto h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir text-tricorn-black border-2">
@@ -52,7 +60,12 @@ const ArticleDetailPage = () => {
           </div>
           <div className="text-base">{articleBody}</div>
           <div className="flex justify-between mt-6">
-            <SubButton label="응원하기" color="blue" type="outline" />
+            <SubButton
+              label="응원하기"
+              onClick={() => handleLikePost()}
+              color="blue"
+              type={likePushed ? 'fill' : 'outline'}
+            />
             <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
           </div>
         </div>
@@ -67,7 +80,7 @@ const ArticleDetailPage = () => {
           <Comments comments={comments} />
         )}
       </section>
-      {isLoginUser && <CommentInput />}
+      {isLoginUser && <CommentInput postId={_id} />}
     </div>
   );
 };

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -3,8 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { BsTrash } from 'react-icons/bs';
 import { FiEdit } from 'react-icons/fi';
 import { deleteLikePost, likePost } from '@/api/common/Like';
-//import { fetchPost } from '@/api/common/Post';
-//import { getPostId } from '@/utils/getPostId';
+import { deletePost } from '@/api/common/Post';
 import ArticleDetail from '@components/ArticleDetail';
 import ArticleInfoIcon from '@components/ArticleInfoIcon';
 import BackButton from '@components/BackButton';
@@ -66,6 +65,19 @@ const ArticleDetailPage = () => {
     }
   };
 
+  const handleDeletePost = async () => {
+    try {
+      const deleted = await deletePost(_id);
+      if (deleted) {
+        navigate('/news');
+      } else {
+        alert('게시물 삭제에 실패했습니다');
+      }
+    } catch (error) {
+      alert(error);
+    }
+  };
+
   return (
     <div className="flex flex-col items-center max-w-[25.875rem] mx-auto mb-9 h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir text-tricorn-black">
       <section className="post-field max-w-[22rem] w-full">
@@ -77,7 +89,7 @@ const ArticleDetailPage = () => {
               <button type="button" name="edit">
                 <FiEdit className="w-[1rem] h-[1rem]" />
               </button>
-              <button type="button" name="delete">
+              <button type="button" name="delete" onClick={handleDeletePost}>
                 <BsTrash className="w-[1rem] h-[1rem]" />
               </button>
             </div>

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -18,6 +18,7 @@ const ArticleDetailPage = () => {
   const { user } = useAuthContext();
   const navigate = useNavigate();
   const [likePushed, setLikePushed] = useState(false);
+  const [likesCount, setLikesCount] = useState(article?.likes.length);
 
   if (isFetching) {
     return <Loader />;
@@ -30,8 +31,25 @@ const ArticleDetailPage = () => {
   const isLoginUser = user ? true : false;
 
   const handleLikePost = () => {
-    likePushed ? deleteLikePost(_id) : likePost(_id);
-    setLikePushed((prevLikePushed) => !prevLikePushed);
+    if (user && likePushed) {
+      //좋아요 취소
+      try {
+        deleteLikePost(user._id);
+        setLikePushed(false);
+        setLikesCount((prevCount) => (prevCount ? prevCount - 1 : likes.length - 1));
+      } catch (error) {
+        //console.error('좋아요 취소 실패', error);
+      }
+    } else {
+      //좋아요 누름름
+      try {
+        likePost(_id);
+        setLikePushed(true);
+        setLikesCount((prevCount) => (prevCount ? prevCount + 1 : likes.length + 1));
+      } catch (error) {
+        //console.error('좋아요 실패!', error);
+      }
+    }
   };
 
   return (
@@ -66,7 +84,11 @@ const ArticleDetailPage = () => {
               color="blue"
               type={likePushed ? 'fill' : 'outline'}
             />
-            <ArticleInfoIcon likes={likes.length} comments={comments.length} mode="post" />
+            <ArticleInfoIcon
+              likes={likesCount ? likesCount : likes.length}
+              comments={comments.length}
+              mode="post"
+            />
           </div>
         </div>
         <div className="banner mt-[10%] mb-[5%] border-b-[0.01rem] border-lazy-gray" />

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -127,7 +127,7 @@ const ArticleDetailPage = () => {
           </div>
         ) : (
           <div className="mb-[10rem]">
-            <Comments comments={comments} />
+            <Comments comments={comments} userId={user ? user._id : null} />
           </div>
         )}
       </section>

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BsTrash } from 'react-icons/bs';
 import { FiEdit } from 'react-icons/fi';
@@ -17,16 +17,18 @@ import Comments from './ArticleDetailPage/Comments';
 
 const ArticleDetailPage = () => {
   const { data: article, isFetching, addComment } = useArticleDetail();
-  // const postId=getPostId()
-  // const articleDetail=fetchPost(postId)
-
-  //#TODO isFetching 문제 해결해야 함
-  //#TODO 좋아요 누른 포스트의 경우 버튼이 활성화되어 있어야 함
-
   const { user } = useAuthContext();
   const navigate = useNavigate();
   const [likePushed, setLikePushed] = useState(false);
   const [likesCount, setLikesCount] = useState(article?.likes.length);
+
+  useEffect(() => {
+    // user가 로드되었을 때 isPostLiked 설정
+    if (user) {
+      const isPostLiked = user.likes.some((like) => like.post === article?._id);
+      setLikePushed(isPostLiked);
+    }
+  }, [user, article]);
 
   if (isFetching) {
     return <Loader />;
@@ -38,7 +40,6 @@ const ArticleDetailPage = () => {
 
   const isMyPost = user ? user._id === postUserId : false;
   const isLoginUser = user ? true : false;
-  //const isPostLiked = user ? likes.some((like) => like.user === user._id) : false;
 
   const handleLikePost = async () => {
     if (user && likePushed) {

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -27,7 +27,7 @@ const ArticleDetailPage = () => {
   const isLoginUser = user ? true : false;
 
   return (
-    <div className="flex flex-col items-center max-w-[25.875rem] mx-auto h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir border-2">
+    <div className="flex flex-col items-center max-w-[25.875rem] mx-auto h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir text-tricorn-black border-2">
       <div className="flex justify-center" />
       <section className="post-field max-w-[22rem] w-full">
         <div className="flex justify-between">

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -67,7 +67,7 @@ const ArticleDetailPage = () => {
   };
 
   return (
-    <div className="flex flex-col items-center max-w-[25.875rem] mx-auto mb-9 h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir text-tricorn-black border-2">
+    <div className="flex flex-col items-center max-w-[25.875rem] mx-auto mb-9 h-[56rem] pt-[2.75rem] font-Cafe24SurroundAir text-tricorn-black">
       <section className="post-field max-w-[22rem] w-full">
         <div className="flex justify-between">
           <BackButton onClick={() => navigate(-1)} />
@@ -114,7 +114,9 @@ const ArticleDetailPage = () => {
             <span className="text-xs text-gray-400">댓글이 없습니다</span>
           </div>
         ) : (
-          <Comments comments={comments} />
+          <div className="mb-[10rem]">
+            <Comments comments={comments} />
+          </div>
         )}
       </section>
       {isLoginUser && <CommentInput onAddComment={addComment} postId={_id} />}

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -66,12 +66,8 @@ const ArticleDetailPage = () => {
 
   const handleDeletePost = async () => {
     try {
-      const deleted = await deletePost(_id);
-      if (deleted) {
-        navigate('/news');
-      } else {
-        alert('게시물 삭제에 실패했습니다');
-      }
+      await deletePost(_id);
+      navigate('/news');
     } catch (error) {
       alert(error);
     }

--- a/src/pages/ArticleDetailPage/CommentInput.tsx
+++ b/src/pages/ArticleDetailPage/CommentInput.tsx
@@ -17,6 +17,7 @@ const CommentInput = ({ onAddComment, postId }: CommentInputProps) => {
     register,
     handleSubmit,
     formState: { errors },
+    reset,
   } = useForm<FormValueType>();
 
   const onSubmit: SubmitHandler<FormValueType> = (data) => {
@@ -27,6 +28,7 @@ const CommentInput = ({ onAddComment, postId }: CommentInputProps) => {
         postId,
       };
       onAddComment(newComment);
+      reset();
     } catch (error) {
       alert(error);
     }

--- a/src/pages/ArticleDetailPage/CommentInput.tsx
+++ b/src/pages/ArticleDetailPage/CommentInput.tsx
@@ -1,12 +1,17 @@
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { RiQuillPenFill } from 'react-icons/ri';
+import { createComment } from '@/api/common/Comment';
 import Avatar from '@components/Avatar';
+
+type CommentInputProps = {
+  postId: string;
+};
 
 type FormValueType = {
   comment: string;
 };
 
-const CommentInput = () => {
+const CommentInput = ({ postId }: CommentInputProps) => {
   const {
     register,
     handleSubmit,
@@ -16,6 +21,7 @@ const CommentInput = () => {
   const onSubmit: SubmitHandler<FormValueType> = (data) => {
     try {
       alert(JSON.stringify(data));
+      createComment({ ...data, postId });
     } catch (error) {
       alert(error);
     }

--- a/src/pages/ArticleDetailPage/CommentInput.tsx
+++ b/src/pages/ArticleDetailPage/CommentInput.tsx
@@ -1,9 +1,10 @@
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { RiQuillPenFill } from 'react-icons/ri';
-import { createComment } from '@/api/common/Comment';
+import { CommentParams } from '@/api/common/Comment';
 import Avatar from '@components/Avatar';
 
 type CommentInputProps = {
+  onAddComment: (comment: CommentParams) => void;
   postId: string;
 };
 
@@ -11,7 +12,7 @@ type FormValueType = {
   comment: string;
 };
 
-const CommentInput = ({ postId }: CommentInputProps) => {
+const CommentInput = ({ onAddComment, postId }: CommentInputProps) => {
   const {
     register,
     handleSubmit,
@@ -20,8 +21,12 @@ const CommentInput = ({ postId }: CommentInputProps) => {
 
   const onSubmit: SubmitHandler<FormValueType> = (data) => {
     try {
-      alert(JSON.stringify(data));
-      createComment({ ...data, postId });
+      // alert(JSON.stringify(data));
+      const newComment = {
+        ...data,
+        postId,
+      };
+      onAddComment(newComment);
     } catch (error) {
       alert(error);
     }
@@ -31,10 +36,10 @@ const CommentInput = ({ postId }: CommentInputProps) => {
     <div className="fixed bottom-2 flex justify-center items-center max-w-[24.875rem] w-full max-h-[3.75rem] h-full rounded-2xl bg-[#EEF1F4] font-Cafe24SurroundAir">
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="flex justify-between w-[23rem]">
-          <div className="flex justify-center items-center">
+          <div className="flex items-center justify-center">
             <Avatar width={1.5} profileImage="" isLoggedIn={false} />
           </div>
-          <div className="flex justify-center items-center">
+          <div className="flex items-center justify-center">
             <input
               {...register('comment', {
                 required: '댓글을 작성해주세요',
@@ -48,7 +53,7 @@ const CommentInput = ({ postId }: CommentInputProps) => {
               maxLength={200}
             />
           </div>
-          <div className="flex justify-center items-center">
+          <div className="flex items-center justify-center">
             <button className="outline-none cursor-pointer">
               <RiQuillPenFill className="fill-cooled-blue w-[1.5rem] h-[1.5rem]" />
             </button>

--- a/src/pages/ArticleDetailPage/CommentInput.tsx
+++ b/src/pages/ArticleDetailPage/CommentInput.tsx
@@ -21,17 +21,13 @@ const CommentInput = ({ onAddComment, postId }: CommentInputProps) => {
   } = useForm<FormValueType>();
 
   const onSubmit: SubmitHandler<FormValueType> = (data) => {
-    try {
-      // alert(JSON.stringify(data));
-      const newComment = {
-        ...data,
-        postId,
-      };
-      onAddComment(newComment);
-      reset();
-    } catch (error) {
-      alert(error);
-    }
+    // alert(JSON.stringify(data));
+    const newComment = {
+      ...data,
+      postId,
+    };
+    onAddComment(newComment);
+    reset();
   };
 
   return (

--- a/src/pages/ArticleDetailPage/Comments.tsx
+++ b/src/pages/ArticleDetailPage/Comments.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Comment as CommentType } from '@type/Comment';
 import { deleteComment } from '@/api/common/Comment';
 import Comment from '@components/Comment';
@@ -24,7 +24,11 @@ const Comments = ({ comments, userId }: CommentsProps) => {
     }
   };
 
-  return comments?.map((comment_post) => {
+  useEffect(() => {
+    setCommentList(comments);
+  }, [comments]);
+
+  return commentList?.map((comment_post) => {
     const { _id, comment, author, createdAt } = comment_post;
     const { fullName, _id: authorId } = author;
     const isMyComment = userId === authorId;

--- a/src/pages/ArticleDetailPage/Comments.tsx
+++ b/src/pages/ArticleDetailPage/Comments.tsx
@@ -1,23 +1,44 @@
+import { useState } from 'react';
 import { Comment as CommentType } from '@type/Comment';
+import { deleteComment } from '@/api/common/Comment';
 import Comment from '@components/Comment';
 
 type CommentsProps = {
   comments: CommentType[];
+  userId: string | null;
 };
 
-const Comments = ({ comments }: CommentsProps) => {
+const Comments = ({ comments, userId }: CommentsProps) => {
+  const [commentList, setCommentList] = useState<CommentType[]>(comments);
+
+  const handleDeleteComment = async (commentId: string) => {
+    try {
+      await deleteComment(commentId);
+      const updatedComments = commentList.filter((comment) => comment._id !== commentId);
+      setCommentList(updatedComments);
+      //console.log(commentList);
+
+      alert('댓글 삭제 완료');
+    } catch (error) {
+      alert(error);
+    }
+  };
+
   return comments?.map((comment_post) => {
     const { _id, comment, author, createdAt } = comment_post;
-    const { fullName } = author;
+    const { fullName, _id: authorId } = author;
+    const isMyComment = userId === authorId;
 
     try {
       return (
         <Comment
           key={_id}
+          commentId={_id}
           content={comment}
           postedDate={createdAt}
           nickname={fullName}
-          active={false}
+          active={isMyComment}
+          onDelete={(commentId) => handleDeleteComment(commentId)}
         />
       );
     } catch (error) {

--- a/src/pages/NewArticlePage.tsx
+++ b/src/pages/NewArticlePage.tsx
@@ -7,6 +7,7 @@ import CloseButton from '@/components/CloseButton';
 import HeaderText from '@/components/HeaderText';
 import { DROPDOWN_OPTIONS, LENGTH_LIMIT, MESSAGE } from '@/constants/NewArticle';
 import { useArticle } from '@/hooks/useArticle';
+import { useAuthContext } from '@/hooks/useAuthContext';
 
 // TODO: 사용자 로그인 정보 불러오기
 // TODO: 작성한 게시물 id값 불러오기
@@ -19,8 +20,16 @@ type FormValueType = {
 
 const NewArticlePage = () => {
   const navigate = useNavigate();
+  const { user } = useAuthContext();
   const [selectedText, setSelectedText] = useState('');
   const [titleCount, setTitleCount] = useState(0);
+
+  if (!user) {
+    alert('로그인 후 글을 쓸 수 있습니다!');
+    navigate('/home');
+  }
+
+  const { fullName, image: profileImage } = user!;
 
   const {
     register,
@@ -33,7 +42,6 @@ const NewArticlePage = () => {
 
   const onSubmit: SubmitHandler<FormValueType> = (data) => {
     try {
-      alert(JSON.stringify(data));
       addArticle.mutate({ ...data, image });
     } catch (error) {
       alert(error);
@@ -71,7 +79,7 @@ const NewArticlePage = () => {
   };
 
   return (
-    <div className="max-w-[25.875rem] mx-auto max-h-[56rem] h-full pt-[2.75rem] position:relative bg-cooled-blue font-Cafe24SurroundAir">
+    <div className="max-w-[25.875rem] mx-auto max-h-[56rem] h-full pt-[2.75rem] position:relative bg-cooled-blue text-tricorn-black font-Cafe24SurroundAir">
       <header className="flex flex-col">
         <div className="flex justify-between items-center mb-[1.75rem] ml-[2.44rem] mr-[1.56rem]">
           <HeaderText size="normal" label="글쓰기" />
@@ -81,9 +89,13 @@ const NewArticlePage = () => {
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="flex flex-col h-[48.5rem]  bg-white rounded-t-3xl">
           <div className="flex items-center justify-between mx-auto w-full max-w-[22.625rem] pt-[2rem]">
-            <Avatar width={2.5} profileImage="" isLoggedIn={false} />
+            <Avatar
+              width={2.5}
+              profileImage={profileImage ? profileImage : ''}
+              isLoggedIn={false}
+            />
             <div className="flex w-[12.5rem]">
-              <span className="font-Cafe24Surround">닉네임</span>
+              <span className="font-Cafe24Surround">{fullName}</span>
             </div>
             <button className="w-[6rem] h-[2.2rem] rounded-lg bg-cooled-blue font-Cafe24Surround text-white cursor-pointer">
               작성하기


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #131 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
게시글 상세 페이지를 구현했습니다. 
- [x] 현재 사용자의 정보를 불러옵니다. 
- [x] 로그인을 하지 않은 유저일 시 댓글 입력 창이 보이지 않습니다. 
- [x] 자신이 작성한 글이 아닐 시 수정/삭제 버튼이 보이지 않습니다. 
- [x] 자신이 작성한 댓글이 아닐 시 댓글 삭제 버튼이 보이지 않습니다. 
- [x] 로그인 한 사용자는 댓글을 작성할 수 있습니다.
- [x] 댓글을 단 사용자는 자신의 댓글을 삭제할 수 있습니다. 
- [x] 로그인 한 사용자는 게시글에 좋아요를 누를 수 있습니다.
- [x] 로그인 한 사용자는 게시글에 좋아요 취소를 누를 수 있습니다. 
- [x] 자신이 작성한 글을 삭제할 수 있습니다. 

# TODO
## in 글 상세 페이지
- [ ] 로그인을 하지 않은 유저일 시 좋아요 버튼을 누르면 로그인 안내 모달창을 띄워줍니다. 
- [ ] 좋아요 버튼을 누를 시 '좋아요를 누르시겠습니까?', '좋아요를 취소하겠습니까?' 와 같은 모달창을 띄워줍니다. 
- [ ] 게시글 삭제 버튼을 누를 시 '게시글을 삭제하시겠습니까?'와 같은 모달창을 띄워줍니다. 
- [ ] 좋아요 버튼 활성화 로직을 수정해야 합니다. 
- [ ] 수정 버튼 클릭 시 글 작성 페이지로 이동해야 합니다. 이때, 글 작성 페이지에서 받는 props는 수정하는 글의 작성자 정보, 제목, 내용이어야 합니다. 

## in 게시글 페이지
- [ ] 게시글 삭제 후 news 페이지로 이동 시 news 페이지에서 삭제된 게시물은 보여주지 않아야 합니다. 
- [ ] 게시글 좋아요/좋아요 취소 후 news 페이지로 이동 시 news 페이지에서 좋아요 수가 바로 반영되어야 합니다. 
- [ ] 게시글 댓글게시/삭제 후 news 페이지로 이동 시 news 페이지에서 댓글 수가 바로 반영되어야 합니다. 
- [ ] 글 작성 후 news 페이지로 이동 시 작성된 글이 news 페이지에서 바로 반영되어야 합니다. 


## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

![ezgif com-video-to-gif](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/98521882/b56fe06a-98b5-4085-85c8-671c11c01110)

- 사용자가 좋아요 누른 글의 id와 현재 보고 있는 글의 id가 같을 시 좋아요 버튼은 활성화 되어 있습니다. 
- 버튼이 활성화 되어 있는 상태에서 버튼을 누르면 좋아요 취소가 작동합니다. 
- 버튼이 비활성화 되어 있는 상태에서 버튼을 누르면 좋아요가 작동합니다. 
- 이 모든 동작은 새로고침을 해야 정상적으로 동작합니다. 예를 들어, 좋아요 버튼을 연속으로 두 번 누르고 페이지를 이동했다가 다시 들어가면 좋아요 버튼이 여전히 활성화 되어 있습니다. 
- 이 부분에 대해 어제 하루종일 고민하였지만 역량부족으로 해결하지 못했습니다... 

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 좋아요 로직에 대해 많은 첨언 부탁드립니다...
- 게시물 페이지에서 글 상세 정보 변경 시 바로 반영하는 것이 가능한가요? 
- 상수분리나 리팩토링은 새로운 issue를 파서 진행하도록 하겠습니다!

