### PR TITLE
feat: protect Router 추가

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, Navigate } from 'react-router-dom';
-import Loader from '@/components/Loader';
 import MainButton from '@/components/MainButton';
 import { useAuthContext } from '@/hooks/useAuthContext';
+import { LoadingPage } from '@pages/index';
 
 const LOGO_SRC = '/img/logo.svg';
 const CHARACTER_SRC = '/img/character.png';
@@ -18,11 +18,7 @@ const LandingPage = () => {
   };
 
   if (user === undefined) {
-    return (
-      <div className="flex justify-center items-center w-full h-screen">
-        <Loader size="lg" />
-      </div>
-    );
+    return <LoadingPage />;
   }
 
   if (user === null) {

--- a/src/pages/LoadingPage.tsx
+++ b/src/pages/LoadingPage.tsx
@@ -1,0 +1,11 @@
+import Loader from '@/components/Loader';
+
+const LoadingPage = () => {
+  return (
+    <div className="flex justify-center items-center w-full h-screen">
+      <Loader size="lg" />
+    </div>
+  );
+};
+
+export default LoadingPage;

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -1,24 +1,11 @@
-import { Navigate } from 'react-router-dom';
 import CloseButton from '@/components/CloseButton';
 import HeaderText from '@/components/HeaderText';
-import Loader from '@/components/Loader';
 import { useAuthContext } from '@/hooks/useAuthContext';
+import type { User } from '@/type/User';
 import EditForm from './ProfileEditPage/EditForm';
 
 const ProfileEditPage = () => {
   const { user } = useAuthContext();
-
-  if (user === undefined) {
-    return (
-      <div className="flex justify-center items-center w-full h-screen">
-        <Loader size="lg" />
-      </div>
-    );
-  }
-
-  if (user === null) {
-    return <Navigate to="/login" replace />;
-  }
 
   return (
     <section className="grid grid-rows-[1fr_8fr] h-screen bg-white overflow-y-auto dark:bg-[#1D232A]">
@@ -28,7 +15,7 @@ const ProfileEditPage = () => {
           <CloseButton />
         </div>
       </header>
-      <EditForm user={user} />
+      <EditForm user={user! as User} />
     </section>
   );
 };

--- a/src/pages/ProtectedRouter.tsx
+++ b/src/pages/ProtectedRouter.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthContext } from '@/hooks/useAuthContext';
+import { LoadingPage } from '.';
+
+const ProtectedRouter = ({ children }: { children: ReactNode }) => {
+  const { user } = useAuthContext();
+
+  if (user === undefined) {
+    return <LoadingPage />;
+  }
+
+  if (user === null) {
+    alert('권한이 필요한 페이지입니다');
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRouter;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -11,3 +11,5 @@ export { default as SearchPage } from './SearchPage';
 export { default as SignUpPage } from './SignupPage';
 export { default as ProfileEditPage } from './ProfileEditPage';
 export { default as ChangePasswordPage } from './ChangePasswordPage';
+export { default as LoadingPage } from './LoadingPage';
+export { default as ProtectedRouter } from './ProtectedRouter';

--- a/src/utils/Router.tsx
+++ b/src/utils/Router.tsx
@@ -14,6 +14,7 @@ import {
   ArticlesPage,
   ProfileEditPage,
   ChangePasswordPage,
+  ProtectedRouter,
 } from '@pages/index';
 
 const router = createBrowserRouter([
@@ -26,14 +27,49 @@ const router = createBrowserRouter([
       { path: 'home', element: <HomePage /> },
       { path: 'signUp', element: <SignUpPage /> },
       { path: 'search', element: <SearchPage /> },
-      { path: 'profile/:userId', element: <ProfilePage /> },
+      {
+        path: 'profile/:userId',
+        element: (
+          <ProtectedRouter>
+            <ProfilePage />
+          </ProtectedRouter>
+        ),
+      },
       { path: 'login', element: <LoginPage /> },
       { path: 'news', element: <ArticlesPage /> },
-      { path: 'news/create', element: <NewArticlePage /> },
+      {
+        path: 'news/create',
+        element: (
+          <ProtectedRouter>
+            <NewArticlePage />
+          </ProtectedRouter>
+        ),
+      },
       { path: 'news/:postId', element: <ArticleDetailPage /> },
-      { path: 'notification', element: <NotificationPage /> },
-      { path: 'profile/edit', element: <ProfileEditPage /> },
-      { path: 'password', element: <ChangePasswordPage /> },
+      {
+        path: 'notification',
+        element: (
+          <ProtectedRouter>
+            <NotificationPage />
+          </ProtectedRouter>
+        ),
+      },
+      {
+        path: 'profile/edit',
+        element: (
+          <ProtectedRouter>
+            <ProfileEditPage />
+          </ProtectedRouter>
+        ),
+      },
+      {
+        path: 'password',
+        element: (
+          <ProtectedRouter>
+            <ChangePasswordPage />
+          </ProtectedRouter>
+        ),
+      },
     ],
   },
 ]);


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #148 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- Protected Router 컴포넌트를 만들었습니다
- 로딩 페이지를 추가했습니다
- 권한 없이 권한이 필요한 페이지에 들어가면 alert 메시지를 보여주고 로그인 페이지로 라우팅 시킵니다.
## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![Protect router](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43432783/c71bf80e-8516-4173-9fe5-bb74eeb7d7bc)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- alert가 뜨는 동안 흰화면인게 신경 쓰이네요. 좋은 방법이 있을까요?
- 로그인 페이지로 보낼때 replace 모드로 보냈는데 push로 보내는게 나을까요?
- 프로필 페이지에서 userId에 해당하는 유저의 정보를 받지 못했을때 에러 처리가 필요할 것 같습니다