### PR TITLE
feat: 홈페이지 게시물 불러오기 구현

### DIFF
--- a/src/constants/Home.ts
+++ b/src/constants/Home.ts
@@ -1,0 +1,10 @@
+export const POST_COUNT = {
+  NEWEST: 6,
+  HOTTEST: 4,
+};
+
+export const MESSAGE = {
+  HOME: '홈',
+  HOTTEST_NEWS: '뜨거운 뉴스',
+  NEWEST: '최신 뉴스',
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -42,6 +42,7 @@ const HomePage = () => {
                   likes={0}
                   comments={1}
                 />
+
                 <Article
                   title="되겠냐?"
                   id="1"
@@ -148,11 +149,29 @@ const HomePage = () => {
                 likes={0}
                 comments={1}
               />
+              <Article
+                title="되겠냐?"
+                id="1"
+                nickname="@khakhiD"
+                postedDate="2023-08-29T09:28:39.390Z"
+                hasImage={true}
+                likes={0}
+                comments={1}
+              />
+              <Article
+                title="되겠냐?"
+                id="1"
+                nickname="@khakhiD"
+                postedDate="2023-08-29T09:28:39.390Z"
+                hasImage={true}
+                likes={0}
+                comments={1}
+              />
             </ul>
           </div>
         </section>
       </div>
-      <footer className="sticky bottom-0 flex-none justify-center items-center">
+      <footer className="fixed bottom-0 flex-none justify-center items-center">
         <BottomNavigation currentPage="/home" />
       </footer>
     </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { HiFire } from 'react-icons/hi';
 import { MdOutlineSearch } from 'react-icons/md';
 import Loader from '@/components/Loader';
 import { API } from '@/constants/Article';
+import { MESSAGE, POST_COUNT } from '@/constants/Home';
 import { TAB_CONSTANTS } from '@/constants/Tab';
 import { useArticles } from '@/hooks/useArticles';
 import { useFilteredArticles } from '@/hooks/useFilteredArticles';
@@ -20,16 +21,22 @@ const HomePage = () => {
     type: 'channel',
   });
 
-  const newestArticles = useFilteredArticles(TAB_CONSTANTS.NEWEST, articles).slice(0, 6);
-  const hottestArticles = useFilteredArticles(TAB_CONSTANTS.HOTTEST, articles).slice(0, 4);
+  const newestArticles = useFilteredArticles(TAB_CONSTANTS.NEWEST, articles).slice(
+    0,
+    POST_COUNT.NEWEST,
+  );
+  const hottestArticles = useFilteredArticles(TAB_CONSTANTS.HOTTEST, articles).slice(
+    0,
+    POST_COUNT.HOTTEST,
+  );
 
   return (
     <div className="relative flex flex-col justify-center items-center overflow-hidden">
       <div className="w-full max-w-md flex flex-col gap-36 overflow-y-scroll">
         <section className="bg-cooled-blue h-[375px] mb-10">
           <header className="flex h-[180px] justify-between px-10 items-center">
-            <HeaderText label="홈" />
-            <MdOutlineSearch size="24" className="text-tricorn-black" />
+            <HeaderText label={MESSAGE.HOME} />
+            <MdOutlineSearch size="24" className="text-tricorn-black cursor-pointer" />
           </header>
           <section className="relative w-full h-[304px] gap-2 flex justify-center">
             <div className="w-10/12 max-w-[374px] flex flex-col gap-2">
@@ -37,7 +44,7 @@ const HomePage = () => {
                 <HiFire size="24" className="text-article-highly-liked" />
                 <h2 className="flex-none text-tricorn-black font-Cafe24Surround text-lg font-bold">
                   <span onClick={() => navigate('/news')} className="cursor-pointer">
-                    뜨거운 뉴스
+                    {MESSAGE.HOTTEST_NEWS}
                   </span>
                 </h2>
               </div>
@@ -65,7 +72,7 @@ const HomePage = () => {
           <div className="flex flex-col gap-3">
             <h2 className="text-tricorn-black font-Cafe24Surround text-lg font-bold px-7">
               <span onClick={() => navigate('/news')} className="cursor-pointer">
-                최신 이야기
+                {MESSAGE.NEWEST}
               </span>
             </h2>
             <div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,12 +1,28 @@
+import { useNavigate } from 'react-router-dom';
 import { HiFire } from 'react-icons/hi';
 import { MdOutlineSearch } from 'react-icons/md';
-import Article from '@components/Article';
+import Loader from '@/components/Loader';
+import { API } from '@/constants/Article';
+import { TAB_CONSTANTS } from '@/constants/Tab';
+import { useArticles } from '@/hooks/useArticles';
+import { useFilteredArticles } from '@/hooks/useFilteredArticles';
 import BottomNavigation from '@components/BottomNavigation';
 import HeaderText from '@components/HeaderText';
+import Articles from './ArticlesPage/Articles';
 
 const CHARACTER_SRC = '/img/character.png';
 
 const HomePage = () => {
+  const navigate = useNavigate();
+
+  const { data: articles, isFetching } = useArticles({
+    id: API.CHANNEL_ID,
+    type: 'channel',
+  });
+
+  const newestArticles = useFilteredArticles(TAB_CONSTANTS.NEWEST, articles).slice(0, 6);
+  const hottestArticles = useFilteredArticles(TAB_CONSTANTS.HOTTEST, articles).slice(0, 4);
+
   return (
     <div className="relative flex flex-col justify-center items-center overflow-hidden">
       <div className="w-full max-w-md flex flex-col gap-36 overflow-y-scroll">
@@ -20,47 +36,21 @@ const HomePage = () => {
               <div className="flex items-center">
                 <HiFire size="24" className="text-article-highly-liked" />
                 <h2 className="flex-none text-tricorn-black font-Cafe24Surround text-lg font-bold">
-                  뜨거운 뉴스
+                  <span onClick={() => navigate('/news')} className="cursor-pointer">
+                    뜨거운 뉴스
+                  </span>
                 </h2>
               </div>
               <div className="bg-white text-black w-full rounded-xl shadow-article-container max-w-sm self-center h-[304px] z-20">
-                <Article
-                  title="되겠냐?"
-                  id="1"
-                  nickname="@khakhiD"
-                  postedDate="2023-08-29T09:28:39.390Z"
-                  hasImage={true}
-                  likes={0}
-                  comments={1}
-                />
-                <Article
-                  title="되겠냐?"
-                  id="1"
-                  nickname="@khakhiD"
-                  postedDate="2023-08-29T09:28:39.390Z"
-                  hasImage={true}
-                  likes={0}
-                  comments={1}
-                />
-
-                <Article
-                  title="되겠냐?"
-                  id="1"
-                  nickname="@khakhiD"
-                  postedDate="2023-08-29T09:28:39.390Z"
-                  hasImage={true}
-                  likes={0}
-                  comments={1}
-                />
-                <Article
-                  title="되겠냐?"
-                  id="1"
-                  nickname="@khakhiD"
-                  postedDate="2023-08-29T09:28:39.390Z"
-                  hasImage={true}
-                  likes={0}
-                  comments={1}
-                />
+                <div>
+                  {isFetching ? (
+                    <div className="flex justify-center">
+                      <Loader />
+                    </div>
+                  ) : (
+                    <Articles articles={hottestArticles} />
+                  )}
+                </div>
               </div>
               <img
                 src={CHARACTER_SRC}
@@ -71,103 +61,22 @@ const HomePage = () => {
           </section>
         </section>
         <section className=" bg-white flex flex-col justify-center gap-6 flex-grow">
-          <div className="bg-emerald-300 w-[280px] h-20 self-center" />
+          {/* <div className="bg-emerald-300 w-[280px] h-20 self-center" /> */}
           <div className="flex flex-col gap-3">
             <h2 className="text-tricorn-black font-Cafe24Surround text-lg font-bold px-7">
-              최신 이야기
+              <span onClick={() => navigate('/news')} className="cursor-pointer">
+                최신 이야기
+              </span>
             </h2>
-            <ul>
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-              <Article
-                title="되겠냐?"
-                id="1"
-                nickname="@khakhiD"
-                postedDate="2023-08-29T09:28:39.390Z"
-                hasImage={true}
-                likes={0}
-                comments={1}
-              />
-            </ul>
+            <div>
+              {isFetching ? (
+                <div className="flex justify-center">
+                  <Loader />
+                </div>
+              ) : (
+                <Articles articles={newestArticles} />
+              )}
+            </div>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #154 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 홈페이지에서 인기뉴스와 최신뉴스를 각각 4개, 6개씩 불러와 보여줍니다. 
- '뜨거운 뉴스', '최신 뉴스'를 클릭하면 news 페이지로 이동합니다. 

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![ezgif com-video-to-gif (2)](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/98521882/517a7c83-4b8c-45ed-82b1-70baa2d6b72c)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
인기탭으로 이동하는 건 추후에 하기로 했습니다.   