### PR TITLE
refactor: 게시글 페이지 중복 처리 + 탭 상수화, useTab훅으로 관리

### DIFF
--- a/src/components/SearchResultList.tsx
+++ b/src/components/SearchResultList.tsx
@@ -1,5 +1,6 @@
 import type { SearchData } from '@type/search';
 import { SearchType } from '@constants/Search';
+import { TAB_CONSTANTS } from '@constants/Tab';
 import useFilteredSearchResult from '@hooks/useFilteredSearchResult';
 import { useTabContext } from '@hooks/useTabContext';
 import Article from './Article';
@@ -11,7 +12,7 @@ const SearchResultList = ({ data }: SearchData) => {
   return (
     filteredData &&
     filteredData.map((searchResult, index) => {
-      if (activeTab === 'item1' && SearchType.TITLE in searchResult) {
+      if (activeTab === TAB_CONSTANTS.ARTICLE_TITLE && SearchType.TITLE in searchResult) {
         const { _id, title, author, createdAt, likes, image, comments } = searchResult;
         const { fullName } = author;
         const { title: articleTitle } = title ? JSON.parse(title) : { title: '' };
@@ -31,7 +32,7 @@ const SearchResultList = ({ data }: SearchData) => {
             />
           </div>
         );
-      } else if (activeTab === 'item2' && SearchType.ROLE in searchResult) {
+      } else if (activeTab === TAB_CONSTANTS.NICKNAME && SearchType.ROLE in searchResult) {
         const { _id, fullName, image } = searchResult;
         return (
           <div key={_id}>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
+import { TAB_CONSTANTS } from '@constants/Tab';
 import { useTabContext } from '@hooks/useTabContext';
+import { getKeyByValue } from '@utils/getKeyByValue';
 
 type TabItemProps = {
   title: string;
@@ -17,7 +19,7 @@ type TabProps = {
 
 const Tab = ({ active, maxWidth, defaultTab, tabItems }: TabProps) => {
   const { activeTab, setActiveTab } = useTabContext();
-  const activeIndex = Number(activeTab.slice(-1)) - 1;
+  const activeIndex = getKeyByValue(TAB_CONSTANTS, activeTab);
 
   useEffect(() => {
     if (active) {
@@ -29,26 +31,29 @@ const Tab = ({ active, maxWidth, defaultTab, tabItems }: TabProps) => {
 
   return (
     <div className="flex" style={{ maxWidth: `${maxWidth}rem` }}>
-      {tabItems.map((tabItem, index) => (
-        <div
-          key={index}
-          style={{ width: `${tabItem.width}rem` }}
-          className={`font-Cafe24Surround cursor-pointer flex items-center justify-center h-[2.5rem] text-[1.125rem] border-b-2 ${
-            activeIndex === index ? 'text-cooled-blue border-cooled-blue' : 'text-lazy-gray'
-          }`}
-          onClick={() => {
-            tabItem.onClick?.();
-            setActiveTab(`item${index + 1}`);
-          }}
-        >
-          <span className={`${activeIndex === index ? 'text-cooled-blue' : 'text-lazy-gray'}`}>
-            {tabItem.icon}
-          </span>
-          <span className={`${activeIndex === index ? 'text-cooled-blue' : 'text-lazy-gray'}`}>
-            {tabItem.title}
-          </span>
-        </div>
-      ))}
+      {tabItems.map((tabItem, index) => {
+        const isActive = TAB_CONSTANTS[activeIndex as keyof typeof TAB_CONSTANTS] === tabItem.title;
+        return (
+          <div
+            key={index}
+            style={{ width: `${tabItem.width}rem` }}
+            className={`font-Cafe24Surround cursor-pointer flex items-center justify-center h-[2.5rem] text-[1.125rem] border-b-2 ${
+              isActive ? 'text-cooled-blue border-cooled-blue' : 'text-lazy-gray'
+            }`}
+            onClick={() => {
+              tabItem.onClick?.();
+              setActiveTab(tabItem.title);
+            }}
+          >
+            <span className={`${isActive ? 'text-cooled-blue' : 'text-lazy-gray'}`}>
+              {tabItem.icon}
+            </span>
+            <span className={`${isActive ? 'text-cooled-blue' : 'text-lazy-gray'}`}>
+              {tabItem.title}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/constants/Tab.ts
+++ b/src/constants/Tab.ts
@@ -6,4 +6,8 @@ export enum TAB_CONSTANTS {
   SUBSCRIBED = '구독한',
   SUBSCRIBER = '구독자',
   SUBSCRIBING = '구독중',
+  WRITTEN_ARTICLES = '작성한 기사',
+  LIKED_ARTICLES = '응원한 기사',
 }
+
+export const LOCAL_STORAGE_CURRENT_TAB_KEY = 'CURRENT_TAB';

--- a/src/hooks/useFilteredSearchResult.tsx
+++ b/src/hooks/useFilteredSearchResult.tsx
@@ -1,11 +1,12 @@
 import type { SearchData } from '@type/search';
 import { SearchType } from '@constants/Search';
+import { TAB_CONSTANTS } from '@constants/Tab';
 import { useTabContext } from './useTabContext';
 
 const useFilteredSearchResult = ({ data }: SearchData) => {
   const { activeTab } = useTabContext();
   const filteredData =
-    activeTab === 'item1'
+    activeTab === TAB_CONSTANTS.ARTICLE_TITLE
       ? data?.filter((searchResult) => SearchType.TITLE in searchResult)
       : data?.filter((searchResult) => SearchType.ROLE in searchResult);
 

--- a/src/hooks/useTab.tsx
+++ b/src/hooks/useTab.tsx
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+import { LOCAL_STORAGE_CURRENT_TAB_KEY, TAB_CONSTANTS } from '@/constants/Tab';
+import { getItemFromStorage, setItemToStorage } from '@/utils/localStorage';
+
+const useTab = () => {
+  const changeTab = (newTab: string) => {
+    setCurrentTab(newTab);
+    setItemToStorage(LOCAL_STORAGE_CURRENT_TAB_KEY, newTab);
+  };
+  const [currentTab, setCurrentTab] = useState(
+    getItemFromStorage(LOCAL_STORAGE_CURRENT_TAB_KEY) || TAB_CONSTANTS.NEWEST,
+  );
+
+  return { currentTab, changeTab };
+};
+
+export default useTab;

--- a/src/pages/ArticlesPage.tsx
+++ b/src/pages/ArticlesPage.tsx
@@ -1,28 +1,27 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { Follow } from '@type/Follow';
 import { AiOutlineArrowUp } from 'react-icons/ai';
 import { BsFire } from 'react-icons/bs';
 import { MdOutlineSearch, MdStars } from 'react-icons/md';
-import { fetchUserPosts } from '@/api/common/Post';
-import BottomNavigation from '@/components/BottomNavigation';
-import { API, ARTICLE_FETCH_LIMIT } from '@/constants/Article';
-import useAuthQuery from '@/hooks/useAuthQuery';
-import useScrollToTop from '@/hooks/useScrollToTop';
-import { Follow } from '@/type/Follow';
-import { getItemFromStorage, setItemToStorage } from '@/utils/localStorage';
+import { fetchUserPosts } from '@api/common/Post';
+import BottomNavigation from '@components/BottomNavigation';
 import HeaderText from '@components/HeaderText';
 import Loader from '@components/Loader';
 import Tab from '@components/Tab';
 import TabItem from '@components/TabItem';
-import { TAB_CONSTANTS } from '@constants/Tab';
+import { API, ARTICLE_FETCH_LIMIT } from '@constants/Article';
+import { LOCAL_STORAGE_CURRENT_TAB_KEY, TAB_CONSTANTS } from '@constants/Tab';
 import { TabContextProvider } from '@context/TabContext';
 import { useArticles } from '@hooks/useArticles';
+import useAuthQuery from '@hooks/useAuthQuery';
 import { useFilteredArticles } from '@hooks/useFilteredArticles';
+import useScrollToTop from '@hooks/useScrollToTop';
+import useTab from '@hooks/useTab';
+import { getItemFromStorage } from '@utils/localStorage';
 import Articles from './ArticlesPage/Articles';
 import InfiniteScroll from './ArticlesPage/InfiniteScroll';
-
-const LOCAL_STORAGE_CURRENT_TAB_KEY = 'CURRENT_TAB';
 
 const ArticlesPage = () => {
   const { data: articles, isFetching } = useArticles({
@@ -31,10 +30,8 @@ const ArticlesPage = () => {
   });
   const newestArticles = useFilteredArticles(TAB_CONSTANTS.NEWEST, articles);
   const hottestArticles = useFilteredArticles(TAB_CONSTANTS.HOTTEST, articles);
+  const { currentTab, changeTab } = useTab();
   const [followingUsers, setFollowingUsers] = useState<Follow[]>([]);
-  const [currentTab, setCurrentTab] = useState(
-    getItemFromStorage(LOCAL_STORAGE_CURRENT_TAB_KEY) || 'item1',
-  );
 
   const {
     userQuery: { data: user },
@@ -42,11 +39,6 @@ const ArticlesPage = () => {
   const navigate = useNavigate();
 
   const { ref: scrollRef, showScrollToTopButton, scrollToTop } = useScrollToTop();
-
-  const changeTab = (newTab: string) => {
-    setCurrentTab(newTab);
-    setItemToStorage(LOCAL_STORAGE_CURRENT_TAB_KEY, newTab);
-  };
 
   const fetchFollowingArticles = useCallback(
     async ({ pageParam = 0 }) => {
@@ -77,9 +69,9 @@ const ArticlesPage = () => {
   useEffect(() => {
     const savedTab = getItemFromStorage(LOCAL_STORAGE_CURRENT_TAB_KEY);
     if (savedTab) {
-      setCurrentTab(savedTab);
+      changeTab(savedTab);
     }
-  }, [currentTab]);
+  }, [currentTab, changeTab]);
 
   useEffect(() => {
     if (user) {
@@ -107,25 +99,25 @@ const ArticlesPage = () => {
               {
                 title: `${TAB_CONSTANTS.NEWEST}`,
                 width: '8.625',
-                onClick: () => changeTab('item1'),
+                onClick: () => changeTab(TAB_CONSTANTS.NEWEST),
               },
               {
                 title: `${TAB_CONSTANTS.HOTTEST}`,
                 icon: <BsFire className="w-[1.3rem] h-[1.3rem]" />,
                 width: '8.625',
-                onClick: () => changeTab('item2'),
+                onClick: () => changeTab(TAB_CONSTANTS.HOTTEST),
               },
               {
                 title: `${TAB_CONSTANTS.SUBSCRIBED}`,
                 icon: <MdStars className="w-[1.5rem] h-[1.5rem]" />,
                 width: '8.625',
-                onClick: () => changeTab('item3'),
+                onClick: () => changeTab(TAB_CONSTANTS.SUBSCRIBED),
               },
             ]}
           />
         </header>
         <article ref={scrollRef} className="flex-grow gap-4 overflow-y-auto">
-          <TabItem index="item1">
+          <TabItem index={`${TAB_CONSTANTS.NEWEST}`}>
             {isFetching ? (
               <div className="flex justify-center">
                 <Loader />
@@ -134,7 +126,7 @@ const ArticlesPage = () => {
               <Articles articles={newestArticles} />
             )}
           </TabItem>
-          <TabItem index="item2">
+          <TabItem index={`${TAB_CONSTANTS.HOTTEST}`}>
             {isFetching ? (
               <div className="flex justify-center">
                 <Loader />
@@ -143,7 +135,7 @@ const ArticlesPage = () => {
               <Articles articles={hottestArticles} />
             )}
           </TabItem>
-          <TabItem index="item3">
+          <TabItem index={`${TAB_CONSTANTS.SUBSCRIBED}`}>
             {isFetching ? (
               <div className="flex justify-center">
                 <Loader />

--- a/src/pages/ArticlesPage/Articles.tsx
+++ b/src/pages/ArticlesPage/Articles.tsx
@@ -1,8 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 import { Post } from '@type/Post';
-import SubButton from '@/components/SubButton';
-import { API } from '@/constants/Article';
 import Article from '@components/Article';
+import SubButton from '@components/SubButton';
+import { API } from '@constants/Article';
 
 type ArticlesProps = {
   articles: Post[];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,20 +1,22 @@
 import { useNavigate } from 'react-router-dom';
 import { HiFire } from 'react-icons/hi';
 import { MdOutlineSearch } from 'react-icons/md';
-import Loader from '@/components/Loader';
-import { API } from '@/constants/Article';
-import { MESSAGE, POST_COUNT } from '@/constants/Home';
-import { TAB_CONSTANTS } from '@/constants/Tab';
-import { useArticles } from '@/hooks/useArticles';
-import { useFilteredArticles } from '@/hooks/useFilteredArticles';
 import BottomNavigation from '@components/BottomNavigation';
 import HeaderText from '@components/HeaderText';
+import Loader from '@components/Loader';
+import { API } from '@constants/Article';
+import { MESSAGE, POST_COUNT } from '@constants/Home';
+import { TAB_CONSTANTS } from '@constants/Tab';
+import { useArticles } from '@hooks/useArticles';
+import { useFilteredArticles } from '@hooks/useFilteredArticles';
+import useTab from '@hooks/useTab';
 import Articles from './ArticlesPage/Articles';
 
 const CHARACTER_SRC = '/img/character.png';
 
 const HomePage = () => {
   const navigate = useNavigate();
+  const { changeTab } = useTab();
 
   const { data: articles, isFetching } = useArticles({
     id: API.CHANNEL_ID,
@@ -43,8 +45,14 @@ const HomePage = () => {
               <div className="flex items-center">
                 <HiFire size="24" className="text-article-highly-liked" />
                 <h2 className="flex-none text-tricorn-black font-Cafe24Surround text-lg font-bold">
-                  <span onClick={() => navigate('/news')} className="cursor-pointer">
-                    {MESSAGE.HOTTEST_NEWS}
+                  <span
+                    onClick={() => {
+                      navigate('/news');
+                      changeTab(TAB_CONSTANTS.HOTTEST);
+                    }}
+                    className="cursor-pointer"
+                  >
+                    {TAB_CONSTANTS.HOTTEST} 뉴스
                   </span>
                 </h2>
               </div>
@@ -71,8 +79,14 @@ const HomePage = () => {
           {/* <div className="bg-emerald-300 w-[280px] h-20 self-center" /> */}
           <div className="flex flex-col gap-3">
             <h2 className="text-tricorn-black font-Cafe24Surround text-lg font-bold px-7">
-              <span onClick={() => navigate('/news')} className="cursor-pointer">
-                {MESSAGE.NEWEST}
+              <span
+                onClick={() => {
+                  navigate('/news');
+                  changeTab(TAB_CONSTANTS.NEWEST);
+                }}
+                className="cursor-pointer"
+              >
+                {TAB_CONSTANTS.NEWEST} 뉴스
               </span>
             </h2>
             <div>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -93,8 +93,20 @@ const ProfilePage = () => {
                 </span>
               </div>
               <SubscribeInfo
-                subscriber={currentProfileUser ? currentProfileUser.followers.length : 0}
-                subscribing={currentProfileUser ? currentProfileUser.following.length : 0}
+                subscriber={
+                  currentProfileUser
+                    ? Array.from(
+                        new Set(currentProfileUser.followers.map((follower) => follower.user)),
+                      ).length
+                    : 0
+                }
+                subscribing={
+                  currentProfileUser
+                    ? Array.from(
+                        new Set(currentProfileUser.following.map((follower) => follower.user)),
+                      ).length
+                    : 0
+                }
               />
               <span className="text-center px-[2.8rem] mt-[1rem]">
                 {currentProfileUser ? currentProfileUser.username : '자기소개가 없습니다.'}
@@ -132,9 +144,14 @@ const ProfilePage = () => {
               </div>
             )}
             {currentProfileUser && currentProfileUser.likes.length > 0 ? (
-              currentProfileUser.likes.map((likeArticle) => (
-                <LikeArticles key={likeArticle.post} likeArticle={likeArticle} />
-              ))
+              Array.from(new Set(currentProfileUser.likes.map((like) => like.post))).map(
+                (postId) => {
+                  const likeArticle = currentProfileUser.likes.find((like) => like.post === postId);
+                  return likeArticle ? (
+                    <LikeArticles key={postId} likeArticle={likeArticle} />
+                  ) : null;
+                },
+              )
             ) : (
               <div className="flex justify-center">
                 <span className="text-center text-lazy-gray">응원한 기사가 없습니다.</span>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,19 +1,21 @@
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import getUserInfo from '@/api/getUserInfo';
-import Loader from '@/components/Loader';
-import ScrollToTopButton from '@/components/ScrollToTopButton';
-import useAuthQuery from '@/hooks/useAuthQuery';
-import useScrollToTop from '@/hooks/useScrollToTop';
-import { User } from '@/type/User';
+import { User } from '@type/User';
+import getUserInfo from '@api/getUserInfo';
 import Avatar from '@components/Avatar';
 import BackButton from '@components/BackButton';
 import BottomNavigation from '@components/BottomNavigation';
+import Loader from '@components/Loader';
+import ScrollToTopButton from '@components/ScrollToTopButton';
 import SubscribeInfo from '@components/SubscribeInfo';
 import Tab from '@components/Tab';
 import TabItem from '@components/TabItem';
+import { TAB_CONSTANTS } from '@constants/Tab';
 import { TabContextProvider } from '@context/TabContext';
+import useAuthQuery from '@hooks/useAuthQuery';
+import useScrollToTop from '@hooks/useScrollToTop';
+import useTab from '@hooks/useTab';
 import LikeArticles from './ProfilePage/LikeArticles';
 import UserArticles from './ProfilePage/UserArticles';
 
@@ -21,6 +23,7 @@ const ProfilePage = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const { ref, showScrollToTopButton, scrollToTop } = useScrollToTop();
+  const { changeTab } = useTab();
 
   const pathSegments = location.pathname.split('/');
   const lastSegment = pathSegments[pathSegments.length - 1];
@@ -115,15 +118,23 @@ const ProfilePage = () => {
           </div>
           <Tab
             maxWidth="25.875"
-            defaultTab="item1"
+            defaultTab={`${TAB_CONSTANTS.WRITTEN_ARTICLES}`}
             tabItems={[
-              { title: '작성한 기사', width: '12.9375' },
-              { title: '응원한 기사', width: '12.9375' },
+              {
+                title: '작성한 기사',
+                width: '12.9375',
+                onClick: () => changeTab(TAB_CONSTANTS.WRITTEN_ARTICLES),
+              },
+              {
+                title: '응원한 기사',
+                width: '12.9375',
+                onClick: () => changeTab(TAB_CONSTANTS.LIKED_ARTICLES),
+              },
             ]}
           />
         </header>
         <article ref={ref} className="flex-grow overflow-y-auto">
-          <TabItem index="item1">
+          <TabItem index={`${TAB_CONSTANTS.WRITTEN_ARTICLES}`}>
             {isFetching && (
               <div className="flex items-center justify-center">
                 <Loader />
@@ -137,7 +148,7 @@ const ProfilePage = () => {
               </div>
             )}
           </TabItem>
-          <TabItem index="item2">
+          <TabItem index={`${TAB_CONSTANTS.LIKED_ARTICLES}`}>
             {isFetching && (
               <div className="flex items-center justify-center">
                 <Loader />

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -14,15 +14,17 @@ import { TabContextProvider } from '@context/TabContext';
 import useDebounceValue from '@hooks/useDebounce';
 import useRecentResult from '@hooks/useRecentResult';
 import useSearch from '@hooks/useSearch';
+import useTab from '@hooks/useTab';
 const INPUT_CLASS =
   'w-[23.375rem] w-full p-3.5 bg-input-white outline-none  placeholder:text-lazy-gray rounded-lg font-Cafe24SurroundAir shadow-s pl-14';
 
 const SearchPage = () => {
-  const [keyword, setKeyword] = useState<string>('');
+  const [keyword, setKeyword] = useState('');
   const debouncedKeyword = useDebounceValue(keyword, DEBOUNCE_TIME);
   const { data, isFetching, isSuccess } = useSearch({ keyword: debouncedKeyword });
   const recentResult = useRecentResult({ isSuccess, keyword: debouncedKeyword });
   const navigate = useNavigate();
+  const { changeTab } = useTab();
   const handleRecentResult = (keyword: string) => {
     setKeyword(keyword);
   };
@@ -51,10 +53,18 @@ const SearchPage = () => {
               <div className="pt-[1.63rem]">
                 <Tab
                   maxWidth="23.375"
-                  defaultTab="item1"
+                  defaultTab={`${TAB_CONSTANTS.ARTICLE_TITLE}`}
                   tabItems={[
-                    { title: `${TAB_CONSTANTS.ARTICLE_TITLE}`, width: '11.6875' },
-                    { title: `${TAB_CONSTANTS.NICKNAME}`, width: '11.6875' },
+                    {
+                      title: `${TAB_CONSTANTS.ARTICLE_TITLE}`,
+                      width: '11.6875',
+                      onClick: () => changeTab(TAB_CONSTANTS.ARTICLE_TITLE),
+                    },
+                    {
+                      title: `${TAB_CONSTANTS.NICKNAME}`,
+                      width: '11.6875',
+                      onClick: () => changeTab(TAB_CONSTANTS.NICKNAME),
+                    },
                   ]}
                 />
               </div>
@@ -62,14 +72,14 @@ const SearchPage = () => {
           </div>
         </header>
         <article className="flex-grow gap-4 overflow-y-auto pb-[4.75rem]">
-          <TabItem index="item1">
+          <TabItem index={`${TAB_CONSTANTS.ARTICLE_TITLE}`}>
             {isFetching ? (
               <SearchSkeleton SkeletonType={'title'} />
             ) : (
               <SearchResultList data={data} />
             )}
           </TabItem>
-          <TabItem index="item2">
+          <TabItem index={`${TAB_CONSTANTS.NICKNAME}`}>
             {isFetching ? (
               <SearchSkeleton SkeletonType={'user'} />
             ) : (

--- a/src/stories/Tab.stories.tsx
+++ b/src/stories/Tab.stories.tsx
@@ -9,6 +9,7 @@ import Tab from '@components/Tab';
 import TabItem from '@components/TabItem';
 import { TAB_CONSTANTS } from '@constants/Tab';
 import { TabContextProvider } from '@context/TabContext';
+import useTab from '@hooks/useTab';
 
 export default {
   title: 'Tab',
@@ -17,30 +18,37 @@ export default {
 } as Meta;
 
 export const Default = () => {
+  const { changeTab } = useTab();
   return (
     <Router>
       <TabContextProvider>
         <Tab
           maxWidth="25.875"
-          defaultTab="item1"
+          defaultTab={`${TAB_CONSTANTS.NEWEST}`}
           tabItems={[
-            { title: `${TAB_CONSTANTS.NEWEST}`, width: '8.625' },
+            {
+              title: `${TAB_CONSTANTS.NEWEST}`,
+              width: '8.625',
+              onClick: () => changeTab(TAB_CONSTANTS.NEWEST),
+            },
             {
               title: `${TAB_CONSTANTS.HOTTEST}`,
               width: '8.625',
               icon: <BsFire className="w-[1.3rem] h-[1.3rem]" />,
+              onClick: () => changeTab(TAB_CONSTANTS.HOTTEST),
             },
             {
               title: `${TAB_CONSTANTS.SUBSCRIBED}`,
               width: '8.625',
               icon: <MdStars className="w-[1.5rem] h-[1.5rem]" />,
+              onClick: () => changeTab(TAB_CONSTANTS.SUBSCRIBED),
             },
           ]}
         />
-        <TabItem index="item1">
+        <TabItem index={`${TAB_CONSTANTS.NEWEST}`}>
           <Loader />
         </TabItem>
-        <TabItem index="item2">
+        <TabItem index={`${TAB_CONSTANTS.HOTTEST}`}>
           <Article
             id="1"
             title="(임시)이거슨 뜨겁다."
@@ -51,7 +59,7 @@ export const Default = () => {
             comments={42}
           />
         </TabItem>
-        <TabItem index="item3">
+        <TabItem index={`${TAB_CONSTANTS.SUBSCRIBED}`}>
           <Article
             id="1"
             title="(임시)이거슨 구독이다."
@@ -68,21 +76,30 @@ export const Default = () => {
 };
 
 export const TitleAndNicknameTab = () => {
+  const { changeTab } = useTab();
   return (
     <Router>
       <TabContextProvider>
         <Tab
           maxWidth="23.375"
-          defaultTab="item1"
+          defaultTab={`${TAB_CONSTANTS.ARTICLE_TITLE}`}
           tabItems={[
-            { title: `${TAB_CONSTANTS.ARTICLE_TITLE}`, width: '11.6875' },
-            { title: `${TAB_CONSTANTS.NICKNAME}`, width: '11.6875' },
+            {
+              title: `${TAB_CONSTANTS.ARTICLE_TITLE}`,
+              width: '11.6875',
+              onClick: () => changeTab(TAB_CONSTANTS.ARTICLE_TITLE),
+            },
+            {
+              title: `${TAB_CONSTANTS.NICKNAME}`,
+              width: '11.6875',
+              onClick: () => changeTab(TAB_CONSTANTS.NICKNAME),
+            },
           ]}
         />
-        <TabItem index="item1">
+        <TabItem index={`${TAB_CONSTANTS.ARTICLE_TITLE}`}>
           <Loader />
         </TabItem>
-        <TabItem index="item2">
+        <TabItem index={`${TAB_CONSTANTS.NICKNAME}`}>
           <ErrorText text="아직 구독한 사용자가 없습니다." />
         </TabItem>
       </TabContextProvider>
@@ -91,21 +108,30 @@ export const TitleAndNicknameTab = () => {
 };
 
 export const SubscribeTab = () => {
+  const { changeTab } = useTab();
   return (
     <Router>
       <TabContextProvider>
         <Tab
           maxWidth="23.375"
-          defaultTab="item1"
+          defaultTab={`${TAB_CONSTANTS.SUBSCRIBER}`}
           tabItems={[
-            { title: `${TAB_CONSTANTS.SUBSCRIBER}`, width: '11.6875' },
-            { title: `${TAB_CONSTANTS.SUBSCRIBING}`, width: '11.6875' },
+            {
+              title: `${TAB_CONSTANTS.SUBSCRIBER}`,
+              width: '11.6875',
+              onClick: () => changeTab(TAB_CONSTANTS.SUBSCRIBER),
+            },
+            {
+              title: `${TAB_CONSTANTS.SUBSCRIBING}`,
+              width: '11.6875',
+              onClick: () => changeTab(TAB_CONSTANTS.SUBSCRIBING),
+            },
           ]}
         />
-        <TabItem index="item1">
+        <TabItem index={`${TAB_CONSTANTS.SUBSCRIBER}`}>
           <Loader />
         </TabItem>
-        <TabItem index="item2">
+        <TabItem index={`${TAB_CONSTANTS.SUBSCRIBING}`}>
           <Article
             id="1"
             title="(임시)이거슨 구독이다."

--- a/src/type/User.ts
+++ b/src/type/User.ts
@@ -12,7 +12,16 @@ export type User = {
   posts: Post[];
   likes: Like[];
   comments: string[];
-  followers: [];
+  followers: [
+    {
+      _id: string;
+      user: string;
+      follower: string;
+      createdAt: string;
+      updatedAt: string;
+      __v: number;
+    },
+  ];
   following: [
     {
       _id: string;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #171 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 게시글 페이지에서 중복된 게시글들이 나오지 않도록 로직을 수정했습니다.
- 홈페이지에서 뜨거운 뉴스, 최신의 뉴스를 클릭하면 뉴스의 해당 탭으로 이동합니다.
  - 탭을 상수화해서 useTab 훅으로 관리할 수 있도록 수정했습니다.
## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
