### PR TITLE
Fix : 하단 네비게이션바 버그 수정 + 추가사항 수정

### DIFF
--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AiFillHome } from 'react-icons/ai';
 import { BiSolidUserCircle } from 'react-icons/bi';
 import { BsFillBellFill } from 'react-icons/bs';
 import { HiChatBubbleLeftEllipsis } from 'react-icons/hi2';
 import { RiQuillPenFill } from 'react-icons/ri';
+import { TOAST_MESSAGES } from '@/constants/Messages';
 import useAuthQuery from '@/hooks/useAuthQuery';
+import { useToastContext } from '@/hooks/useToastContext';
 
 const NavConstants = {
   HOME: '홈',
@@ -25,14 +26,19 @@ type BottomNavigationProp = {
 
 const BottomNavigation = ({ currentPage }: BottomNavigationProp) => {
   const navigate = useNavigate();
+  const { showToast } = useToastContext();
   const {
     userQuery: { data: user },
   } = useAuthQuery();
-  const [userId, setUserId] = useState('');
 
-  useEffect(() => {
-    setUserId(user ? user._id : '');
-  }, [user]);
+  const handleClickProfile = () => {
+    if (user) {
+      navigate(`/profile/${user._id}`);
+    } else {
+      showToast(TOAST_MESSAGES.NEED_AUTH);
+      navigate('/login');
+    }
+  };
 
   return (
     <div className="flex items-center justify-evenly w-[25.875rem] h-[4.75rem] bg-white dark:bg-tricorn-black shadow-[0_-0.021rem_0_0_rgba(0,0,0,0.3)] dark:shadow-[0_-0.021rem_0_0_rgba(238, 238, 238, 0.5)] font-Cafe24SurroundAir">
@@ -91,26 +97,16 @@ const BottomNavigation = ({ currentPage }: BottomNavigationProp) => {
           {NavConstants.NOTICE}
         </span>
       </button>
-      <button
-        name="profile"
-        onClick={() => {
-          navigate(`/profile/${userId}`);
-        }}
-        className={BASE_BUTTON_STYLE}
-      >
+      <button name="profile" onClick={handleClickProfile} className={BASE_BUTTON_STYLE}>
         <span className={BASE_ICON_STYLE}>
           <BiSolidUserCircle
-            className={`${currentPage === `/profile/${userId}` ? ACTIVE_COLOR : BUTTON_COLOR}`}
+            className={`${currentPage === `/profile` ? ACTIVE_COLOR : BUTTON_COLOR}`}
             aria-hidden="true"
             size="2rem"
             fill="currentColor"
           />
         </span>
-        <span
-          className={`text-sm ${
-            currentPage === `/profile/${userId}` ? ACTIVE_COLOR : BUTTON_COLOR
-          }`}
-        >
+        <span className={`text-sm ${currentPage === `/profile` ? ACTIVE_COLOR : BUTTON_COLOR}`}>
           {NavConstants.MYPAGE}
         </span>
       </button>

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from 'react-icons/ai';
 
 type CloseButtonProps = {
   mode?: 'large' | 'small';
-  onClick?: () => void;
+  onClick?: VoidFunction;
 };
 
 const BASE_BUTTON_CLASSES = 'block bg-transparent rounded-md cursor-pointer hover:bg-lazy-gray/50';

--- a/src/constants/Messages.ts
+++ b/src/constants/Messages.ts
@@ -30,3 +30,7 @@ export const TOAST_MESSAGES = {
   AUTH_USER_FAILED: '유저 정보를 받아오는데 실패했어요.',
   NEED_AUTH: '로그인이 필요해요.',
 };
+
+export const MODAL_MESSAGE = {
+  PROFILE_EDIT_WARN: '수정사항이 사라질 수 있어요',
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -73,7 +73,7 @@ const HomePage = () => {
             </div>
           </section>
         </section>
-        <section className=" bg-white flex flex-col justify-center gap-6 flex-grow">
+        <section className=" bg-white flex flex-col justify-center gap-6 flex-grow pb-20">
           {/* <div className="bg-emerald-300 w-[280px] h-20 self-center" /> */}
           <div className="flex flex-col gap-3">
             <h2 className="text-tricorn-black font-Cafe24Surround text-lg font-bold px-7">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { HiFire } from 'react-icons/hi';
-import { MdOutlineSearch } from 'react-icons/md';
+import { ImSearch } from 'react-icons/im';
 import Loader from '@/components/Loader';
 import { API } from '@/constants/Article';
 import { MESSAGE, POST_COUNT } from '@/constants/Home';
@@ -30,13 +30,19 @@ const HomePage = () => {
     POST_COUNT.HOTTEST,
   );
 
+  const handleClickSearchButton = () => {
+    navigate('/search');
+  };
+
   return (
     <div className="relative flex flex-col justify-center items-center overflow-hidden">
       <div className="w-full max-w-md flex flex-col gap-36 overflow-y-scroll">
         <section className="bg-cooled-blue h-[375px] mb-10">
           <header className="flex h-[180px] justify-between px-10 items-center">
             <HeaderText label={MESSAGE.HOME} />
-            <MdOutlineSearch size="24" className="text-tricorn-black cursor-pointer" />
+            <button onClick={handleClickSearchButton}>
+              <ImSearch size="24" className="text-tricorn-black" />
+            </button>
           </header>
           <section className="relative w-full h-[304px] gap-2 flex justify-center">
             <div className="w-10/12 max-w-[374px] flex flex-col gap-2">

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -19,22 +19,24 @@ const ProfileEditPage = () => {
   };
 
   return (
-    <section className="grid grid-rows-[1fr_8fr] h-screen overflow-y-auto">
-      {showModal && (
-        <Confirm
-          theme="negative"
-          title="수정사항이 사라질 수 있어요"
-          onClose={modalClose}
-          onConfirm={handleClickConfirm}
-        />
-      )}
-      <header className="flex justify-center w-full">
-        <div className="flex items-center justify-between w-full max-w-sm p-4 pt-8">
-          <HeaderText label="프로필 수정" />
-          <CloseButton onClick={modalOpen} />
-        </div>
-      </header>
-      <EditForm user={user! as User} />
+    <section className="flex justify-center h-screen">
+      <div className="flex flex-col justify-center px-2">
+        {showModal && (
+          <Confirm
+            theme="negative"
+            title="수정사항이 사라질 수 있어요"
+            onClose={modalClose}
+            onConfirm={handleClickConfirm}
+          />
+        )}
+        <header className="flex justify-center w-full">
+          <div className="flex items-center justify-between w-full max-w-sm p-6 pt-8">
+            <HeaderText label="프로필 수정" />
+            <CloseButton onClick={modalOpen} />
+          </div>
+        </header>
+        <EditForm user={user! as User} />
+      </div>
     </section>
   );
 };

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import CloseButton from '@/components/CloseButton';
 import HeaderText from '@/components/HeaderText';
 import useAuthQuery from '@/hooks/useAuthQuery';
@@ -9,12 +10,18 @@ const ProfileEditPage = () => {
     userQuery: { data: user },
   } = useAuthQuery();
 
+  const navigate = useNavigate();
+
+  const handleClickCloseButton = () => {
+    navigate(-1);
+  };
+
   return (
     <section className="grid grid-rows-[1fr_8fr] h-screen overflow-y-auto">
       <header className="flex justify-center w-full">
         <div className="flex items-center justify-between w-full max-w-sm p-4 pt-8">
           <HeaderText label="프로필 수정" />
-          <CloseButton />
+          <CloseButton onClick={handleClickCloseButton} />
         </div>
       </header>
       <EditForm user={user! as User} />

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -1,27 +1,37 @@
 import { useNavigate } from 'react-router-dom';
 import CloseButton from '@/components/CloseButton';
 import HeaderText from '@/components/HeaderText';
+import Confirm from '@/components/Modals/Confirm';
 import useAuthQuery from '@/hooks/useAuthQuery';
+import useModal from '@/hooks/useModal';
 import type { User } from '@/type/User';
 import EditForm from './ProfileEditPage/EditForm';
 
 const ProfileEditPage = () => {
+  const navigate = useNavigate();
+  const { showModal, modalOpen, modalClose } = useModal();
   const {
     userQuery: { data: user },
   } = useAuthQuery();
 
-  const navigate = useNavigate();
-
-  const handleClickCloseButton = () => {
+  const handleClickConfirm = () => {
     navigate(-1);
   };
 
   return (
     <section className="grid grid-rows-[1fr_8fr] h-screen overflow-y-auto">
+      {showModal && (
+        <Confirm
+          theme="negative"
+          title="수정사항이 사라질 수 있어요"
+          onClose={modalClose}
+          onConfirm={handleClickConfirm}
+        />
+      )}
       <header className="flex justify-center w-full">
         <div className="flex items-center justify-between w-full max-w-sm p-4 pt-8">
           <HeaderText label="프로필 수정" />
-          <CloseButton onClick={handleClickCloseButton} />
+          <CloseButton onClick={modalOpen} />
         </div>
       </header>
       <EditForm user={user! as User} />

--- a/src/pages/ProfileEditPage.tsx
+++ b/src/pages/ProfileEditPage.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import CloseButton from '@/components/CloseButton';
 import HeaderText from '@/components/HeaderText';
 import Confirm from '@/components/Modals/Confirm';
+import { MODAL_MESSAGE } from '@/constants/Messages';
 import useAuthQuery from '@/hooks/useAuthQuery';
 import useModal from '@/hooks/useModal';
 import type { User } from '@/type/User';
@@ -24,7 +25,7 @@ const ProfileEditPage = () => {
         {showModal && (
           <Confirm
             theme="negative"
-            title="수정사항이 사라질 수 있어요"
+            title={MODAL_MESSAGE.PROFILE_EDIT_WARN}
             onClose={modalClose}
             onConfirm={handleClickConfirm}
           />

--- a/src/pages/ProfileEditPage/EditForm.tsx
+++ b/src/pages/ProfileEditPage/EditForm.tsx
@@ -1,9 +1,6 @@
-import { ChangeEvent, useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
-import { BiSolidUser } from 'react-icons/bi';
-import { HiPencil } from 'react-icons/hi';
-import { updateProfileImage } from '@/api/common/User';
 import MainButton from '@/components/MainButton';
 import useEditProfile from '@/hooks/useEditProfile';
 import { User } from '@/type/User';
@@ -20,7 +17,6 @@ type EditFormProps = {
 const EditForm = ({ user }: EditFormProps) => {
   const navigate = useNavigate();
   const { editProfile, isLoading } = useEditProfile();
-  const [image, setImage] = useState<string | null>(null);
 
   const {
     watch,
@@ -49,7 +45,6 @@ const EditForm = ({ user }: EditFormProps) => {
     setValue('nickname', user.fullName ? user.fullName : '');
     setValue('introduction', user.username ? user.username : '');
     setFocus('nickname');
-    setImage(user.image ? user.image : null);
   }, [setValue, setFocus, user]);
 
   const [nickname, introduction] = [watch('nickname'), watch('introduction')];
@@ -66,43 +61,9 @@ const EditForm = ({ user }: EditFormProps) => {
     editProfile({ fullName: nickname, username: introduction });
   };
 
-  const handleUpLoadImage = async (event: ChangeEvent<HTMLInputElement>) => {
-    const imageFile = event.target.files;
-    if (!imageFile || imageFile.length < 0) {
-      return;
-    }
-    const updatedUser = await updateProfileImage(imageFile[0]);
-    setImage(updatedUser.image as string);
-  };
-
   return (
     <div className="flex justify-center">
       <form className="p-8 flex flex-col gap-3 max-w-sm w-full" onSubmit={handleSubmit(onSubmit)}>
-        <div className="flex flex-col gap-3">
-          <label htmlFor="" className="text-wall-street font-Cafe24Surround font-bold">
-            프로필 사진
-          </label>
-          <div className="relative w-32 h-32 rounded-full bg-profile-bg self-center mb-6 border border-tertiory-gray text-footer-icon">
-            {image ? (
-              <img src={image} className="w-full h-full rounded-full" alt="thumbnail" />
-            ) : (
-              <BiSolidUser className="w-24 h-24 translate-x-4 translate-y-4" />
-            )}
-            <label
-              htmlFor="image"
-              className="absolute right-1 bottom-1 p-1 rounded-full bg-profile-bg border border-tertiory-gray"
-            >
-              <HiPencil className="w-4 h-4" />
-            </label>
-            <input
-              type="file"
-              accept="image/*"
-              className="hidden"
-              id="image"
-              onChange={handleUpLoadImage}
-            />
-          </div>
-        </div>
         <div className="flex flex-col gap-2">
           <div className="flex flex-col">
             <label className="text-wall-street font-Cafe24Surround font-bold">닉네임</label>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -144,7 +144,7 @@ const ProfilePage = () => {
           <ScrollToTopButton show={showScrollToTopButton} onClick={scrollToTop} />
         </article>
         <div>
-          <BottomNavigation currentPage={`/profile/${lastSegment}`} />
+          <BottomNavigation currentPage={`/profile`} />
         </div>
       </section>
     </TabContextProvider>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -44,7 +44,7 @@ export default {
   },
   // eslint-disable-next-line no-undef
   plugins: [require('daisyui')],
-  darkMode: 'class',
+  // darkMode: 'class',
 
   daisyui: {
     themes: [


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #178
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 권한없는 사용자가 네비게이션바의 프로필로고를 누르면 로그인 페이지로 라우팅 시키고 토스트메시지를 보여주었습니다
- 메인 페이지에서 검색 로고를 누르면 search로 이동하도록 했습니다
- 메인 페이지에서 마지막 게시글에 하단 네비게이션에 가려 보이지 않는 버그를 수정했습니다
- 프로필 수정 페이지에서 x버튼을 눌렀을때 모달을 띄워 경고 메시지를 보여주었습니다
- 프로필 수정페이지에서 이미지를 수정하는 기능을 제거했습니다

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
tailwindcss.config.js에 아래의 코드가 있었는데 이 코드 때문에 daisy가 자동으로 시스템 모드에 따라 라이트, 다크모드를 적용하는 것을
비활성화해서 일단은 주석으로 처리했습니다.
```js
darkMode: 'class',
```
- 추후 다크모드 토글버튼을 구현하면 활성화하면 될 것 같습니다
