### PR TITLE
feat: 게시글 페이지 무한스크롤 구현

### DIFF
--- a/src/constants/Tab.ts
+++ b/src/constants/Tab.ts
@@ -5,7 +5,6 @@ export enum TAB_CONSTANTS {
   HOTTEST = '뜨거운',
   SUBSCRIBED = '구독한',
   SUBSCRIBER = '구독자',
-  SUBSCRIBING = '구독중',
   WRITTEN_ARTICLES = '작성한 기사',
   LIKED_ARTICLES = '응원한 기사',
 }

--- a/src/hooks/useArticles.tsx
+++ b/src/hooks/useArticles.tsx
@@ -1,11 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { useInfiniteQuery } from '@tanstack/react-query';
 import { Post } from '@type/Post';
-import { fetchUserPosts } from '@/api/common/Post';
-import { User } from '@/type/User';
 import { axiosClient } from '@api/axiosClient';
 import { API } from '@constants/Article';
-import { ARTICLE_FETCH_LIMIT } from '@constants/Article';
 
 type UseArticlesProps = {
   id?: string;
@@ -14,14 +10,14 @@ type UseArticlesProps = {
 
 const ARTICLES_STALE_TIME = 1000 * 60;
 
-export const useArticles = ({ type }: UseArticlesProps) => {
-  const { data = [], isFetching } = useQuery<Post[]>(
-    ['articles'],
+export const useArticles = ({ id, type }: UseArticlesProps) => {
+  const { data = [], isLoading } = useQuery<Post[]>(
+    ['articles', id, type],
     async () => {
       const requestUrl =
         type === 'user'
-          ? `${API.ARTICLES_URL}${API.AUTHOR_URL}/${API.CHANNEL_ID}`
-          : `${API.ARTICLES_URL}${API.CHANNEL_URL}/${API.CHANNEL_ID}`;
+          ? `${API.ARTICLES_URL}${API.AUTHOR_URL}/${id}`
+          : `${API.ARTICLES_URL}${API.CHANNEL_URL}/${id}`;
       const { data } = await axiosClient.get(requestUrl);
       return data;
     },
@@ -30,26 +26,5 @@ export const useArticles = ({ type }: UseArticlesProps) => {
     },
   );
 
-  return { data, isFetching };
-};
-
-export const useFollowingArticles = (user: User) => {
-  const fetchFollowingArticles = async ({ pageParam = 0 }) => {
-    const newArticles = await Promise.all(
-      user?.following.map((user) =>
-        fetchUserPosts({ offset: pageParam, limit: ARTICLE_FETCH_LIMIT, authorId: user.user }),
-      ),
-    );
-    return newArticles.flat();
-  };
-
-  return useInfiniteQuery(['followingArticles'], fetchFollowingArticles, {
-    getNextPageParam: (lastPage, pages) => {
-      if (lastPage.length < ARTICLE_FETCH_LIMIT) {
-        return undefined;
-      }
-      return pages.length * ARTICLE_FETCH_LIMIT;
-    },
-    enabled: user?.following.length > 0,
-  });
+  return { data, isLoading };
 };

--- a/src/pages/ArticlesPage.tsx
+++ b/src/pages/ArticlesPage.tsx
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Follow } from '@type/Follow';
+import { User } from '@type/User';
 import { AiOutlineArrowUp } from 'react-icons/ai';
 import { BsFire } from 'react-icons/bs';
 import { MdOutlineSearch, MdStars } from 'react-icons/md';
-import { fetchUserPosts } from '@api/common/Post';
 import BottomNavigation from '@components/BottomNavigation';
 import HeaderText from '@components/HeaderText';
 import Loader from '@components/Loader';
@@ -20,15 +20,15 @@ import { useFilteredArticles } from '@hooks/useFilteredArticles';
 import useScrollToTop from '@hooks/useScrollToTop';
 import useTab from '@hooks/useTab';
 import { getItemFromStorage, setItemToStorage } from '@utils/localStorage';
-import Articles from './ArticlesPage/Articles';
+import { fetchArticles } from './ArticlesPage/fetchArticles';
 import InfiniteScroll from './ArticlesPage/InfiniteScroll';
+import RenderArticles from './ArticlesPage/RenderArticles';
 
 const ArticlesPage = () => {
-  const { data: articles, isFetching } = useArticles({
+  const { data: articles, isLoading } = useArticles({
     id: API.CHANNEL_ID,
     type: 'channel',
   });
-  const newestArticles = useFilteredArticles(TAB_CONSTANTS.NEWEST, articles);
   const hottestArticles = useFilteredArticles(TAB_CONSTANTS.HOTTEST, articles);
   const { currentTab, changeTab } = useTab(CURRENT_NEWS_TAB_KEY);
   const [followingUsers, setFollowingUsers] = useState<Follow[]>([]);
@@ -36,25 +36,43 @@ const ArticlesPage = () => {
   const {
     userQuery: { data: user },
   } = useAuthQuery();
-  const navigate = useNavigate();
 
+  const navigate = useNavigate();
   const { ref: scrollRef, showScrollToTopButton, scrollToTop } = useScrollToTop();
 
-  const fetchFollowingArticles = useCallback(
+  const fetchNewest = useCallback(async ({ pageParam = 0 }) => {
+    return fetchArticles({ type: TAB_CONSTANTS.NEWEST, pageParam });
+  }, []);
+
+  const fetchFollowing = useCallback(
     async ({ pageParam = 0 }) => {
-      const newArticles = await Promise.all(
-        followingUsers.map((user) =>
-          fetchUserPosts({ offset: pageParam, limit: ARTICLE_FETCH_LIMIT, authorId: user.user }),
-        ),
-      );
-      return newArticles.flat();
+      return fetchArticles({
+        type: TAB_CONSTANTS.SUBSCRIBED,
+        pageParam,
+        followingUsers: (user as User).following,
+      });
     },
-    [followingUsers],
+    [user],
   );
+
+  const {
+    data: infiniteNewestArticles,
+    fetchNextPage: fetchNextNewestPage,
+    hasNextPage: hasNextNewestPage,
+    isLoading: newestArticlesLoading,
+    isFetching: newestArticlesFetching,
+  } = useInfiniteQuery(['newestArticles'], fetchNewest, {
+    getNextPageParam: (lastPage, pages) => {
+      if (lastPage.length < ARTICLE_FETCH_LIMIT) {
+        return undefined;
+      }
+      return pages.length * ARTICLE_FETCH_LIMIT;
+    },
+  });
 
   const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
     ['followingArticles', followingUsers],
-    fetchFollowingArticles,
+    fetchFollowing,
     {
       getNextPageParam: (lastPage, pages) => {
         if (lastPage.length < ARTICLE_FETCH_LIMIT) {
@@ -117,30 +135,38 @@ const ArticlesPage = () => {
         </header>
         <article ref={scrollRef} className="flex-grow gap-4 overflow-y-auto">
           <TabItem index={`${TAB_CONSTANTS.NEWEST}`}>
-            {isFetching ? (
+            {newestArticlesLoading ? (
               <div className="flex justify-center">
                 <Loader />
               </div>
             ) : (
-              <Articles articles={newestArticles} />
+              <>
+                <RenderArticles articles={infiniteNewestArticles?.pages.flat() || []} />
+                {newestArticlesFetching && (
+                  <div className="flex justify-center">
+                    <Loader />
+                  </div>
+                )}
+                <InfiniteScroll fetchData={fetchNextNewestPage} canFetchMore={hasNextNewestPage} />
+              </>
             )}
           </TabItem>
           <TabItem index={`${TAB_CONSTANTS.HOTTEST}`}>
-            {isFetching ? (
+            {isLoading ? (
               <div className="flex justify-center">
                 <Loader />
               </div>
             ) : (
-              <Articles articles={hottestArticles} />
+              <RenderArticles articles={hottestArticles} />
             )}
           </TabItem>
           <TabItem index={`${TAB_CONSTANTS.SUBSCRIBED}`}>
-            {isFetching ? (
+            {isLoading ? (
               <div className="flex justify-center">
                 <Loader />
               </div>
             ) : (
-              <Articles articles={data?.pages.flat() || []} />
+              <RenderArticles articles={data?.pages.flat() || []} />
             )}
             <InfiniteScroll fetchData={fetchNextPage} canFetchMore={hasNextPage} />
           </TabItem>

--- a/src/pages/ArticlesPage/RenderArticles.tsx
+++ b/src/pages/ArticlesPage/RenderArticles.tsx
@@ -8,9 +8,16 @@ type ArticlesProps = {
   articles: Post[];
 };
 
-const Articles = ({ articles }: ArticlesProps) => {
+const RenderArticles = ({ articles }: ArticlesProps) => {
   const navigate = useNavigate();
-  const isArticlesEmpty = articles && articles.length === 0;
+
+  const filteredArticles = articles
+    .filter((article, index, self) => index === self.findIndex((a) => a._id === article._id))
+    .sort((a, b) => {
+      return new Date(b?.createdAt).getTime() - new Date(a?.createdAt).getTime();
+    });
+
+  const isArticlesEmpty = filteredArticles && filteredArticles.length === 0;
 
   if (isArticlesEmpty) {
     return (
@@ -27,12 +34,6 @@ const Articles = ({ articles }: ArticlesProps) => {
       </div>
     );
   }
-
-  const filteredArticles = articles
-    .filter((article, index, self) => index === self.findIndex((a) => a._id === article._id))
-    .sort((a, b) => {
-      return new Date(b?.createdAt).getTime() - new Date(a?.createdAt).getTime();
-    });
 
   return filteredArticles?.map((article) => {
     const { _id, title, author, createdAt, likes, image, comments } = article;
@@ -57,4 +58,4 @@ const Articles = ({ articles }: ArticlesProps) => {
   });
 };
 
-export default Articles;
+export default RenderArticles;

--- a/src/pages/ArticlesPage/fetchArticles.ts
+++ b/src/pages/ArticlesPage/fetchArticles.ts
@@ -1,0 +1,31 @@
+import { Follow } from '@type/Follow';
+import { fetchAllPosts, fetchUserPosts } from '@api/common/Post';
+import { ARTICLE_FETCH_LIMIT } from '@constants/Article';
+import { TAB_CONSTANTS } from '@constants/Tab';
+
+type FetchArticlesParams = {
+  type: TAB_CONSTANTS.NEWEST | TAB_CONSTANTS.SUBSCRIBED;
+  followingUsers?: Follow[];
+  pageParam?: number;
+};
+
+export const fetchArticles = async ({
+  type,
+  followingUsers,
+  pageParam = 0,
+}: FetchArticlesParams) => {
+  if (type === TAB_CONSTANTS.NEWEST) {
+    return await fetchAllPosts({ offset: pageParam, limit: ARTICLE_FETCH_LIMIT });
+  }
+
+  if (type === TAB_CONSTANTS.SUBSCRIBED && followingUsers) {
+    const newArticles = await Promise.all(
+      followingUsers.map((user) =>
+        fetchUserPosts({ offset: pageParam, limit: ARTICLE_FETCH_LIMIT, authorId: user.user }),
+      ),
+    );
+    return newArticles.flat();
+  }
+
+  throw new Error('Invalid fetch type or missing parameters.');
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ import { useFilteredArticles } from '@/hooks/useFilteredArticles';
 import BottomNavigation from '@components/BottomNavigation';
 import HeaderText from '@components/HeaderText';
 import useTab from '@hooks/useTab';
-import Articles from './ArticlesPage/Articles';
+import RenderArticles from './ArticlesPage/RenderArticles';
 import HotArticles from './HomePage/HotArticles';
 
 const CHARACTER_SRC = '/img/character.png';
@@ -19,7 +19,7 @@ const HomePage = () => {
   const navigate = useNavigate();
   const { changeTab } = useTab(CURRENT_NEWS_TAB_KEY);
 
-  const { data: articles, isFetching } = useArticles({
+  const { data: articles, isLoading } = useArticles({
     id: API.CHANNEL_ID,
     type: 'channel',
   });
@@ -64,7 +64,7 @@ const HomePage = () => {
                 </h2>
               </div>
               <div className="bg-white dark:bg-tricorn-black text-tricorn-black dark:text-lazy-gray w-full rounded-xl shadow-article-container max-w-sm self-center h-[304px] z-20">
-                {isFetching ? (
+                {isLoading ? (
                   <div className="flex items-center justify-center">
                     <Loader />
                   </div>
@@ -95,12 +95,12 @@ const HomePage = () => {
               </span>
             </h2>
             <div className="">
-              {isFetching ? (
+              {isLoading ? (
                 <div className="flex justify-center">
                   <Loader />
                 </div>
               ) : (
-                <Articles articles={newestArticles} />
+                <RenderArticles articles={newestArticles} />
               )}
             </div>
           </div>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -177,7 +177,7 @@ const ProfilePage = () => {
         </header>
         <article ref={ref} className="flex-grow overflow-y-auto">
           <TabItem index={`${TAB_CONSTANTS.WRITTEN_ARTICLES}`}>
-            {currentProfileUser && currentProfileUser.posts.length > 0 ? (
+            {currentProfileUser && currentProfileUser._id && currentProfileUser.posts.length > 0 ? (
               <UserArticles userId={currentProfileUser._id} />
             ) : (
               <div className="flex justify-center">

--- a/src/pages/ProfilePage/LikeArticles.tsx
+++ b/src/pages/ProfilePage/LikeArticles.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import fetchArticleById from '@/api/fetchArticleById';
-import Articles from '../ArticlesPage/Articles';
+import RenderArticles from '../ArticlesPage/RenderArticles';
 
 type LikeArticleProps = {
   likeArticle: {
@@ -14,7 +14,7 @@ const LikeArticles = ({ likeArticle }: LikeArticleProps) => {
   const { data: article } = useQuery(['article', post], () => fetchArticleById(post), {
     staleTime: 1000 * 60,
   });
-  return article ? <Articles articles={[article]} /> : null;
+  return article ? <RenderArticles articles={[article]} /> : null;
 };
 
 export default LikeArticles;

--- a/src/pages/ProfilePage/UserArticles.tsx
+++ b/src/pages/ProfilePage/UserArticles.tsx
@@ -1,16 +1,17 @@
 import { useArticles } from '@hooks/useArticles';
-import Articles from '../ArticlesPage/Articles';
+import RenderArticles from '../ArticlesPage/RenderArticles';
 
 type UserArticlesProps = {
   userId: string;
 };
 
 const UserArticles = ({ userId }: UserArticlesProps) => {
-  const { data: userArticles, isFetching } = useArticles({
+  const { data: userArticles, isLoading } = useArticles({
     id: userId,
     type: 'user',
   });
-  return isFetching ? null : <Articles articles={userArticles} />;
+
+  return isLoading ? null : <RenderArticles articles={userArticles} />;
 };
 
 export default UserArticles;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #205 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 게시글 페이지의 최신 탭에서 무한스크롤을 구현하기 위해 **fetchArticles** 함수와 **useInfiniteQuery**를 사용했습니다.
- 뜨거운 탭의 경우 무한 스크롤을 구현하기가 쉽지 않은 것 같습니다.
  - 필터링을 해주어야 하는데, offset을 10개로 정하다보니 일부분만 받게 되고, 만약 총 10개가 보내지지 않았다면 계속 다른 글들을 보내도록 로직을 작성해야할 텐데 꽤 복잡한 것 같습니다.
- 맨 처음 데이터를 가져오는 것은 isFetching대신 isLoading을 사용하도록 했습니다. 
  - 무한 스크롤의 경우 새로운 글들을 받아올 땐 isFetching을 사용했습니다.
## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![ezgif com-video-to-gif (2)](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43228743/b101616e-05f6-4dbb-b28d-1edb4fe91d4a)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
