### PR TITLE
refactor: 게시글 페이지 탭 별로 컴포넌트 분리

### DIFF
--- a/src/constants/Tab.ts
+++ b/src/constants/Tab.ts
@@ -10,8 +10,8 @@ export enum TAB_CONSTANTS {
 }
 
 export const TOTAL_TAB_WIDTH = '25.875';
-export const TWO_TAB_WIDTH = '12.9375';
-export const THREE_TAB_WIDTH = '8.625';
+export const DOUBLE_TAB_WIDTH = '12.9375';
+export const TRIPLE_TAB_WIDTH = '8.625';
 
 export const CURRENT_NEWS_TAB_KEY = 'CURRENT_NEWS_TAB';
 export const CURRENT_PROFILE_TAB_KEY = 'CURRENT_PROFILE_TAB';

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -29,6 +29,7 @@ export const useArticleDetail = () => {
       Promise.all([
         queryClient.invalidateQueries(['article', postId]),
         queryClient.invalidateQueries(['articles']),
+        queryClient.invalidateQueries(['newestArticles']),
       ]);
       const { userId } = variables;
 

--- a/src/pages/ArticlesPage/RenderArticles.tsx
+++ b/src/pages/ArticlesPage/RenderArticles.tsx
@@ -3,6 +3,7 @@ import { Post } from '@type/Post';
 import Article from '@components/Article';
 import SubButton from '@components/SubButton';
 import { API } from '@constants/Article';
+import { filterArticles } from './filterArticles';
 
 type ArticlesProps = {
   articles: Post[];
@@ -11,12 +12,7 @@ type ArticlesProps = {
 const RenderArticles = ({ articles }: ArticlesProps) => {
   const navigate = useNavigate();
 
-  const filteredArticles = articles
-    .filter((article, index, self) => index === self.findIndex((a) => a._id === article._id))
-    .sort((a, b) => {
-      return new Date(b?.createdAt).getTime() - new Date(a?.createdAt).getTime();
-    });
-
+  const filteredArticles = filterArticles(articles);
   const isArticlesEmpty = filteredArticles && filteredArticles.length === 0;
 
   if (isArticlesEmpty) {

--- a/src/pages/ArticlesPage/RenderFollowingArticles.tsx
+++ b/src/pages/ArticlesPage/RenderFollowingArticles.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import Loader from '@/components/Loader';
+import { ARTICLE_FETCH_LIMIT } from '@/constants/Article';
+import { TAB_CONSTANTS } from '@/constants/Tab';
+import useAuthQuery from '@/hooks/useAuthQuery';
+import { fetchArticles } from './fetchArticles';
+import InfiniteScroll from './InfiniteScroll';
+import RenderArticles from './RenderArticles';
+
+const RenderFollowingArticles = () => {
+  const {
+    userQuery: { data: user },
+  } = useAuthQuery();
+
+  const followingUsersIds = Array.from(new Set(user?.following.map((user) => user.user)));
+
+  const fetchFollowing = useCallback(
+    async ({ pageParam = 0 }) => {
+      return fetchArticles({
+        type: TAB_CONSTANTS.SUBSCRIBED,
+        pageParam,
+        followingUsersIds,
+      });
+    },
+    [followingUsersIds],
+  );
+
+  const { data, fetchNextPage, hasNextPage, isLoading, isFetching } = useInfiniteQuery(
+    ['followingArticles', followingUsersIds],
+    fetchFollowing,
+    {
+      getNextPageParam: (lastPage, pages) => {
+        if (lastPage.length < ARTICLE_FETCH_LIMIT) {
+          return undefined;
+        }
+        return pages.length * ARTICLE_FETCH_LIMIT;
+      },
+    },
+  );
+
+  return (
+    <>
+      {isLoading ? (
+        <div className="flex justify-center">
+          <Loader />
+        </div>
+      ) : (
+        <>
+          {data?.pages.flat().length === 0 && (
+            <div className="flex flex-col items-center justify-center w-full gap-4 mx-auto mt-4">
+              <span className="text-center">
+                앗, 팔로우한 사람들의 글 목록이 존재하지 않습니다!
+              </span>
+            </div>
+          )}
+          <RenderArticles articles={data?.pages.flat() || []} />
+          {isFetching && (
+            <div className="flex justify-center">
+              <Loader />
+            </div>
+          )}
+          <InfiniteScroll fetchData={fetchNextPage} canFetchMore={hasNextPage} />
+        </>
+      )}
+    </>
+  );
+};
+
+export default RenderFollowingArticles;

--- a/src/pages/ArticlesPage/RenderHottestArticles.tsx
+++ b/src/pages/ArticlesPage/RenderHottestArticles.tsx
@@ -1,0 +1,48 @@
+import Article from '@/components/Article';
+import Loader from '@/components/Loader';
+import { API } from '@/constants/Article';
+import { TAB_CONSTANTS } from '@/constants/Tab';
+import { useArticles } from '@/hooks/useArticles';
+import { useFilteredArticles } from '@/hooks/useFilteredArticles';
+
+const RenderHottestArticles = () => {
+  const { data: articles, isLoading } = useArticles({
+    id: API.CHANNEL_ID,
+    type: 'channel',
+  });
+
+  const hottestArticles = useFilteredArticles(TAB_CONSTANTS.HOTTEST, articles);
+
+  return (
+    <>
+      {isLoading && (
+        <div className="flex justify-center">
+          <Loader />
+        </div>
+      )}
+      {hottestArticles?.map((article) => {
+        const { _id, title, author, createdAt, likes, image, comments } = article;
+        const { fullName } = author;
+        try {
+          const { title: articleTitle } = JSON.parse(title);
+          return (
+            <Article
+              key={_id}
+              id={_id}
+              title={articleTitle ? articleTitle : '제목이 없습니다.'}
+              nickname={fullName ? `@${fullName}` : ''}
+              postedDate={createdAt}
+              hasImage={image !== undefined}
+              likes={likes?.length || 0}
+              comments={comments?.length || 0}
+            />
+          );
+        } catch (e) {
+          // title에 JSON.parse가 안되는게 존재하면 에러남.
+        }
+      })}
+    </>
+  );
+};
+
+export default RenderHottestArticles;

--- a/src/pages/ArticlesPage/RenderNewestArticles.tsx
+++ b/src/pages/ArticlesPage/RenderNewestArticles.tsx
@@ -1,0 +1,49 @@
+import { useCallback } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import Loader from '@/components/Loader';
+import { ARTICLE_FETCH_LIMIT } from '@/constants/Article';
+import { TAB_CONSTANTS } from '@/constants/Tab';
+import { fetchArticles } from './fetchArticles';
+import InfiniteScroll from './InfiniteScroll';
+import RenderArticles from './RenderArticles';
+
+const RenderNewestArticles = () => {
+  const fetchNewest = useCallback(async ({ pageParam = 0 }) => {
+    return fetchArticles({ type: TAB_CONSTANTS.NEWEST, pageParam });
+  }, []);
+
+  const { data, fetchNextPage, hasNextPage, isLoading, isFetching } = useInfiniteQuery(
+    ['newestArticles'],
+    fetchNewest,
+    {
+      getNextPageParam: (lastPage, pages) => {
+        if (lastPage.length < ARTICLE_FETCH_LIMIT) {
+          return undefined;
+        }
+        return pages.length * ARTICLE_FETCH_LIMIT;
+      },
+    },
+  );
+
+  return (
+    <>
+      {isLoading ? (
+        <div className="flex justify-center">
+          <Loader />
+        </div>
+      ) : (
+        <>
+          <RenderArticles articles={data?.pages.flat() || []} />
+          {isFetching && (
+            <div className="flex justify-center">
+              <Loader />
+            </div>
+          )}
+          <InfiniteScroll fetchData={fetchNextPage} canFetchMore={hasNextPage} />
+        </>
+      )}
+    </>
+  );
+};
+
+export default RenderNewestArticles;

--- a/src/pages/ArticlesPage/fetchArticles.ts
+++ b/src/pages/ArticlesPage/fetchArticles.ts
@@ -1,17 +1,16 @@
-import { Follow } from '@type/Follow';
 import { fetchAllPosts, fetchUserPosts } from '@api/common/Post';
 import { ARTICLE_FETCH_LIMIT } from '@constants/Article';
 import { TAB_CONSTANTS } from '@constants/Tab';
 
 type FetchArticlesParams = {
   type: TAB_CONSTANTS.NEWEST | TAB_CONSTANTS.SUBSCRIBED;
-  followingUsers?: Follow[];
+  followingUsersIds?: string[];
   pageParam?: number;
 };
 
 export const fetchArticles = async ({
   type,
-  followingUsers,
+  followingUsersIds: followingUsers,
   pageParam = 0,
 }: FetchArticlesParams) => {
   if (type === TAB_CONSTANTS.NEWEST) {
@@ -21,7 +20,7 @@ export const fetchArticles = async ({
   if (type === TAB_CONSTANTS.SUBSCRIBED && followingUsers) {
     const newArticles = await Promise.all(
       followingUsers.map((user) =>
-        fetchUserPosts({ offset: pageParam, limit: ARTICLE_FETCH_LIMIT, authorId: user.user }),
+        fetchUserPosts({ offset: pageParam, limit: ARTICLE_FETCH_LIMIT, authorId: user }),
       ),
     );
     return newArticles.flat();

--- a/src/pages/ArticlesPage/filterArticles.ts
+++ b/src/pages/ArticlesPage/filterArticles.ts
@@ -1,0 +1,9 @@
+import { Post } from '@type/Post';
+
+export const filterArticles = (articles: Post[]) => {
+  return articles
+    .filter((article, index, self) => index === self.findIndex((a) => a._id === article._id))
+    .sort((a, b) => {
+      return new Date(b?.createdAt).getTime() - new Date(a?.createdAt).getTime();
+    });
+};

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -20,7 +20,7 @@ import useScrollToTop from '@hooks/useScrollToTop';
 import useTab from '@hooks/useTab';
 import { useToastContext } from '@hooks/useToastContext';
 import { getItemFromStorage, setItemToStorage } from '@utils/localStorage';
-import { TWO_TAB_WIDTH } from '../constants/Tab';
+import { DOUBLE_TAB_WIDTH } from '../constants/Tab';
 import LikedArticles from './ProfilePage/LikeArticles';
 import UserArticles from './ProfilePage/UserArticles';
 
@@ -160,12 +160,12 @@ const ProfilePage = () => {
             tabItems={[
               {
                 title: TAB_CONSTANTS.WRITTEN_ARTICLES,
-                width: TWO_TAB_WIDTH,
+                width: DOUBLE_TAB_WIDTH,
                 onClick: () => changeTab(TAB_CONSTANTS.WRITTEN_ARTICLES),
               },
               {
                 title: TAB_CONSTANTS.LIKED_ARTICLES,
-                width: TWO_TAB_WIDTH,
+                width: DOUBLE_TAB_WIDTH,
                 onClick: () => changeTab(TAB_CONSTANTS.LIKED_ARTICLES),
               },
             ]}
@@ -173,7 +173,6 @@ const ProfilePage = () => {
         </header>
         <article ref={ref} className="flex-grow overflow-y-auto">
           <TabItem index={`${TAB_CONSTANTS.WRITTEN_ARTICLES}`}>
-
             {userInfo && userInfo.posts.length > 0 ? (
               <UserArticles userId={userInfo._id} />
             ) : (


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #225 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

게시글 페이지의 탭들을 각각의 컴포넌트로 분리했습니다.
- RenderNewestArticles
- RenderHottestArticles
- RenderFollowingArticles

게시글 페이지에 로직이 모두 모여있어서 성능에 이슈가 생긴 것으로 보입니다(데이터 로딩 + context API를 사용하여 리렌더링 발생...). 각 컴포넌트로 분리하니 탭을 클릭할 때에 데이터 로딩이 시작됩니다.
로컬 환경에서 **51-55**점 정도 나오고 있습니다. 빌드해서 배포한 상태에서 테스트하면 점수가 좀 더 올라가지 않을까 생각합니다.

![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43228743/ee0d6e15-351a-42c5-94b1-5e673db29b21)


## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![ezgif com-video-to-gif (5)](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43228743/c170285f-824d-4829-8b81-5a298f392f1c)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 뜨거운 탭의 경우, 전체 게시글을 불러온 후에 정한 값보다 높은 값만 보여주는 식으로 되어 있는데, 뜨거운 탭 컴포넌트를 구현하는 방법이 고민이 됩니다.
  - 홈페이지에서도 전체 게시글을 가져오기 때문에 크게 문제가 되지 않을지도 모르겠습니다.
- 앱의 높이가 달라지면 무한 스크롤이 제대로 동작하지 않습니다. 새 이슈를 만들어 이를 수정하도록 하겠습니다.
