### PR TITLE
feat: 설정 버튼 드롭다운 메뉴 구현 및 사소한 수정

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -11,7 +11,7 @@ const BackButton = ({ onClick, ...props }: BackButtonProps) => {
       onClick={onClick}
       {...props}
     >
-      <AiOutlineLeft className="icon" size="1.083rem" color="tricorn-black" />
+      <AiOutlineLeft className="icon fill-footer-icon dark:fill-lazy-gray" size="1.083rem" />
     </button>
   );
 };

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -24,6 +24,8 @@ import { DOUBLE_TAB_WIDTH } from '../constants/Tab';
 import LikedArticles from './ProfilePage/LikeArticles';
 import UserArticles from './ProfilePage/UserArticles';
 
+const EDIT_PAGE_URL = '/profile/edit';
+
 const ProfilePage = () => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -64,6 +66,40 @@ const ProfilePage = () => {
       : setItemToStorage(CURRENT_PROFILE_TAB_KEY, TAB_CONSTANTS.WRITTEN_ARTICLES);
   }, [currentTab, changeTab]);
 
+  const SettingsDropdown = () => {
+    const dropdownMenu = [
+      { label: '프로필 수정', onClick: () => navigate(EDIT_PAGE_URL) },
+      { label: '로그아웃', onClick: logoutMutate },
+      {
+        label: '테마 변경',
+        onClick: () => {
+          /* TODO 색상 모드 토글 함수 넣어주기 */
+        },
+      },
+    ];
+
+    return (
+      <div className="dropdown dropdown-end">
+        <label
+          tabIndex={0}
+          className="cursor-pointer text-[1.5rem] z-[40] text-footer-icon focus:text-tricorn-black dark:text-lazy-gray dark:focus:text-wall-street"
+        >
+          <IoSettingsSharp />
+        </label>
+        <ul
+          tabIndex={0}
+          className="dropdown-content z-[30] menu p-1 shadow bg-white text-tricorn-black dark:text-lazy-gray dark:bg-tricorn-black border border-lazy-gray rounded-box w-40"
+        >
+          {dropdownMenu.map((item, i) => (
+            <li key={i}>
+              <div onClick={() => item.onClick()}>{item.label}</div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+
   return (
     <TabContextProvider>
       <section className="flex flex-col justify-center h-screen max-w-[25.875rem] mx-auto pt-[3.75rem] font-Cafe24SurroundAir relative overflow-hidden">
@@ -74,16 +110,7 @@ const ProfilePage = () => {
                 navigate(-1);
               }}
             />
-            {isMyProfile && (
-              <div
-                onClick={() => {
-                  logoutMutate();
-                }}
-                className="cursor-pointer h-[1.5rem] p-[1rem] flex items-center justify-center border-[0.05rem] rounded-lg text-[0.875rem]"
-              >
-                로그아웃
-              </div>
-            )}
+            {isMyProfile && <SettingsDropdown />}
           </div>
           <div className="flex justify-center pb-8 mb-[1.2rem] border-b-[0.01rem] border-tertiory-gray relative">
             <div className="flex flex-col items-center">
@@ -122,10 +149,10 @@ const ProfilePage = () => {
                 )}
               </div>
               <div className="flex items-center mt-2 mb-[0.3rem]">
-                <span className="text-center  h-[1.8125rem] font-Cafe24Surround text-[1.375rem] -tracking-[0.01875rem] mr-2">
+                <span className="text-center text-tricorn-black dark:text-white h-[1.8125rem] font-Cafe24Surround text-[1.375rem] -tracking-[0.01875rem] mr-2">
                   {userInfo?.fullName}
                 </span>
-                <span className="text-center max-w-[1.6875rem] h-[1.125rem] text-[0.875rem] text-lazy-gray">
+                <span className="text-center text-wall-street max-w-[1.6875rem] h-[1.125rem] text-[0.875rem] dark:text-lazy-gray">
                   기자
                 </span>
               </div>
@@ -142,16 +169,10 @@ const ProfilePage = () => {
                     : 0
                 }
               />
-              <span className="text-center px-[2.8rem] mt-[1rem]">
+              <span className="text-center px-[2.8rem] mt-[1rem] text-wall-street dark:text-lazy-gray">
                 {userInfo ? userInfo.username : '자기소개가 없습니다.'}
               </span>
             </div>
-            <button
-              className="absolute right-12 top-2 text-[1.5rem]"
-              onClick={() => navigate('/profile/edit')}
-            >
-              <IoSettingsSharp />
-            </button>
           </div>
           <Tab
             active={currentTab}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -70,12 +70,6 @@ const ProfilePage = () => {
     const dropdownMenu = [
       { label: '프로필 수정', onClick: () => navigate(EDIT_PAGE_URL) },
       { label: '로그아웃', onClick: logoutMutate },
-      {
-        label: '테마 변경',
-        onClick: () => {
-          /* TODO 색상 모드 토글 함수 넣어주기 */
-        },
-      },
     ];
 
     return (


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #228 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

### 설정 버튼 드롭다운 메뉴
- **로그아웃 버튼 삭제**
- **설정 버튼을 드롭다운 메뉴로 구현**
  - 프로필 수정, 로그아웃, 테마 변경 의 세 가지 메뉴
  - **[중요] 테마 변경 부분 콜백 함수 필요** 💥

### 사소한 수정
- BackButton 공통 컴포넌트에서 색상이 color 속성으로 들어가 있는 부분을 className에 넣도록 수정했습니다.
  - 기존 코드는 동작하지 않는 코드입니다.
- ProfilePage 페이지 컴포넌트에 다크모드와 라이트모드의 텍스트 색상을 넣어줬습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

<div align="center">

![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/39e203e9-b08f-4fba-a1b9-d0f9803f5c75)
**[라이트 모드]**

![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/6fbfd627-2727-4be3-a837-7cde77edc7ac)
**[다크 모드]**

</div>


## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
**[중요] 테마 변경 부분 콜백 함수 필요** 💥
- 라이트/다크 모드 토글 함수가 만들어지면 드롭다운 메뉴의 '테마 변경' 메뉴의 콜백 함수로 넣어줘야 합니다.

### 9/25 오후 5:30 수정사항
- 드롭다운 메뉴 중 테마 변경 메뉴 삭제