### PR TITLE
feat: 설정 드롭다운 비밀번호 변경 버튼 추가 및 사소한 수정

### DIFF
--- a/src/constants/Messages.ts
+++ b/src/constants/Messages.ts
@@ -26,6 +26,7 @@ export const TOAST_MESSAGES = {
 
   EDIT_PROFILE_SUCCESS: '회원정보가 수정되었어요.',
   EDIT_PROFILE_FAILED: '회원정보 수정 도중 오류가 발생했어요.',
+  EDIT_PROFILE_INVALID: '기존 정보와 같아요.',
 
   CHANGE_PASSWORD_SUCCESS: '비밀번호가 변경되었어요.',
   CHANGE_PASSWORD_FAILED: '비밀번호 변경 도중 오류가 발생했어요.',

--- a/src/pages/ProfileEditPage/EditForm.tsx
+++ b/src/pages/ProfileEditPage/EditForm.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
 import MainButton from '@/components/MainButton';
+import { TOAST_MESSAGES } from '@/constants/Messages';
 import useEditProfile from '@/hooks/useEditProfile';
+import { useToastContext } from '@/hooks/useToastContext';
 import { User } from '@/type/User';
 
 type FormValue = {
@@ -15,7 +16,7 @@ type EditFormProps = {
 };
 
 const EditForm = ({ user }: EditFormProps) => {
-  const navigate = useNavigate();
+  const { showToast } = useToastContext();
   const { editProfile, isLoading } = useEditProfile();
 
   const {
@@ -49,13 +50,9 @@ const EditForm = ({ user }: EditFormProps) => {
 
   const [nickname, introduction] = [watch('nickname'), watch('introduction')];
 
-  const handleClickPasswordButton = () => {
-    navigate('/password');
-  };
-
   const onSubmit: SubmitHandler<FormValue> = ({ nickname, introduction }) => {
     if (isNotProfileChanged({ nickname, introduction })) {
-      alert('기존 정보와 같습니다');
+      showToast(TOAST_MESSAGES.EDIT_PROFILE_INVALID, 'error');
       return;
     }
     editProfile({ fullName: nickname, username: introduction });
@@ -121,14 +118,8 @@ const EditForm = ({ user }: EditFormProps) => {
             {introduction.length} / 30
           </small>
         </div>
-        <div className="flex flex-col items-center mt-5 p-5 gap-5">
+        <div className="flex flex-col justify-center items-center mt-5">
           <MainButton label="프로필 수정" type="submit" isLoading={isLoading} />
-          <button
-            onClick={handleClickPasswordButton}
-            className="mt-[5%] text-[0.9rem] font-Cafe24SurroundAir text-wall-street dark:text-lazy-gray hover:text-wall-street tracking-toast"
-          >
-            비밀번호 변경하기
-          </button>
         </div>
       </form>
     </div>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { BiSolidUser } from 'react-icons/bi';
 import { HiPencil } from 'react-icons/hi';
 import { IoSettingsSharp } from 'react-icons/io5';
+import Confirm from '@/components/Modals/Confirm';
+import useModal from '@/hooks/useModal';
 import { fetchUser } from '@api/common/User';
 import BackButton from '@components/BackButton';
 import BottomNavigation from '@components/BottomNavigation';
@@ -25,6 +27,7 @@ import LikedArticles from './ProfilePage/LikeArticles';
 import UserArticles from './ProfilePage/UserArticles';
 
 const EDIT_PAGE_URL = '/profile/edit';
+const CHANGE_PASSWORD_PAGE_URL = '/password';
 
 const ProfilePage = () => {
   const location = useLocation();
@@ -67,13 +70,25 @@ const ProfilePage = () => {
   }, [currentTab, changeTab]);
 
   const SettingsDropdown = () => {
+    const { showModal, modalOpen, modalClose } = useModal();
+
     const dropdownMenu = [
       { label: '프로필 수정', onClick: () => navigate(EDIT_PAGE_URL) },
-      { label: '로그아웃', onClick: logoutMutate },
+      { label: '비밀번호 변경', onClick: () => navigate(CHANGE_PASSWORD_PAGE_URL) },
+      { label: '로그아웃', onClick: () => modalOpen() },
     ];
 
     return (
       <div className="dropdown dropdown-end">
+        {showModal && (
+          <Confirm
+            theme="negative"
+            title="정말 로그아웃 하시겠어요?"
+            confirmLabel="로그아웃"
+            onClose={modalClose}
+            onConfirm={logoutMutate}
+          />
+        )}
         <label
           tabIndex={0}
           className="cursor-pointer text-[1.5rem] z-[40] text-footer-icon focus:text-tricorn-black dark:text-lazy-gray dark:focus:text-wall-street"


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #236 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
### 추가
- 설정 버튼에 드롭다운 메뉴 '비밀번호 변경' 추가
- 설정 버튼의 드롭다운 메뉴 '로그아웃' 버튼 클릭 시, 모달 추가
### 수정 및 삭제
- 프로필 수정 페이지에서 '비밀번호 변경' 버튼 삭제

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/a9447667-35b7-48d2-9ede-5449ca187879)
**[드롭다운 메뉴 비밀번호 변경 버튼 추가]**

![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/71928275-eb33-4f23-93eb-e1b314252aa7)
**[로그아웃 누를 시, 모달 추가]**

![image](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/74141521/8506417f-8081-44cf-a76d-43da42126888)
**[프로필 수정 페이지에서 비밀번호 변경 버튼 삭제]**

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
