### PR TITLE
fix: 게시글 작성 / 게시글 수정 페이지의 이미지 업데이트 로직 수정

### DIFF
--- a/src/api/common/Post.ts
+++ b/src/api/common/Post.ts
@@ -62,7 +62,7 @@ export const fetchPost = async (postId: string) => {
 type UpdatePostParams = {
   postId: string;
   title: string;
-  image: File | null;
+  image: File | string | undefined | null;
   imageToDeletePublicId?: string;
   channelId: string;
 };

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -7,7 +7,7 @@ type TabItemProps = {
 
 const TabItem = ({ index, children }: TabItemProps) => {
   const { activeTab } = useTabContext();
-  return <div>{activeTab === index && children}</div>;
+  return <>{activeTab === index && children}</>;
 };
 
 export default TabItem;

--- a/src/constants/NewArticle.ts
+++ b/src/constants/NewArticle.ts
@@ -7,7 +7,7 @@ export const DROPDOWN_OPTIONS = [
   '[발칵]',
   '[헉!]',
   '[멘붕]',
-  '알고보니...',
+  '[알고보니...]',
   '[폭소]',
   '[순간포착]',
   '[단독]',
@@ -24,14 +24,16 @@ export const LENGTH_LIMIT = {
 
 export const MESSAGE = {
   TITLE_REQUIRED: '제목을 입력해주세요',
+  TITLE_PREFIX_REQUIRED: '제목 접두사를 선택해주세요',
   TITLE_MINLENGTH: '2글자 이상 입력해주세요',
-  TITLE_MAXLENGTH: '30자 이내로 입력해주세요',
+  TITLE_MAX_LENGTH: '30자 이내로 입력해주세요',
   CONTENT_REQUIRED: '내용을 입력해주세요',
   CONTENT_MINLENGTH: '2글자 이상 입력해주세요',
-  CONTENT_MAXLENGTH: '500자 이내로 입력해주세요',
+  CONTENT_MAX_LENGTH: '500자 이내로 입력해주세요',
 };
 
 export const ETC = {
   HEADER_WRITE: '글쓰기',
+  HEADER_WRITE_EDIT: '글 수정',
   BUTTON_WRITE: '작성하기',
 };

--- a/src/hooks/useArticle.tsx
+++ b/src/hooks/useArticle.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { TOAST_MESSAGES } from '@/constants/Messages';
 import { saveArticle } from '@api/saveArticle';
+import { TOAST_MESSAGES } from '@constants/Messages';
 import { useToastContext } from './useToastContext';
 
 export const useArticle = () => {
@@ -12,8 +12,9 @@ export const useArticle = () => {
   const { mutate: createPost, isLoading } = useMutation(saveArticle, {
     onSuccess: () => {
       Promise.all([
-        queryClient.invalidateQueries(['post']),
-        queryClient.invalidateQueries(['newestAtrticles']),
+        queryClient.invalidateQueries(['newestArticles']),
+        queryClient.invalidateQueries(['articles']),
+        queryClient.invalidateQueries(['followingArticles']),
       ]);
       showToast(TOAST_MESSAGES.POST_SUCCESS, 'success');
       navigate('/news');

--- a/src/hooks/useEdit.tsx
+++ b/src/hooks/useEdit.tsx
@@ -1,8 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { updateUser } from '@/api/common/UserSettings';
-import { TOAST_MESSAGES } from '@/constants/Messages';
 import { updatePost } from '@api/common/Post';
+import { updateUser } from '@api/common/UserSettings';
+import { TOAST_MESSAGES } from '@constants/Messages';
 import { useToastContext } from './useToastContext';
 
 export const useEditProfile = () => {
@@ -30,9 +30,13 @@ export const useEditPost = () => {
 
   const { mutate: editPost, isLoading } = useMutation(updatePost, {
     onSuccess: (post) => {
-      queryClient.setQueryData(['post'], post);
+      Promise.all([
+        queryClient.invalidateQueries(['newestArticles']),
+        queryClient.invalidateQueries(['articles']),
+        queryClient.invalidateQueries(['followingArticles']),
+      ]);
       showToast(TOAST_MESSAGES.EDIT_POST_SUCCESS, 'success');
-      navigate(`/news/${post._id}`, { replace: true });
+      navigate(`/news/${post._id}`);
     },
     onError: () => {
       showToast(TOAST_MESSAGES.EDIT_POST_FAILED, 'error');

--- a/src/hooks/useLikeMutation.ts
+++ b/src/hooks/useLikeMutation.ts
@@ -7,10 +7,11 @@ export const useLikeCreateMutation = () => {
   return useMutation({
     mutationFn: likePost,
     onSuccess: (like) =>
-      Promise.all([
+      Promise.allSettled([
         queryClient.invalidateQueries(['article', like.post]),
         queryClient.invalidateQueries(['newestArticles']),
         queryClient.invalidateQueries(['articles']),
+        queryClient.invalidateQueries(['followingArticles', like._id]),
         queryClient.invalidateQueries(['user']),
       ]),
   });
@@ -22,10 +23,11 @@ export const useLikeDeleteMutation = () => {
   return useMutation({
     mutationFn: deleteLikePost,
     onSuccess: (like) =>
-      Promise.all([
+      Promise.allSettled([
         queryClient.invalidateQueries(['article', like.post]),
         queryClient.invalidateQueries(['newestArticles']),
         queryClient.invalidateQueries(['articles']),
+        queryClient.invalidateQueries(['followingArticles', like._id]),
         queryClient.invalidateQueries(['user']),
       ]),
   });

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -2,18 +2,18 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BsTrash } from 'react-icons/bs';
 import { FiEdit } from 'react-icons/fi';
-import Confirm from '@/components/Modals/Confirm';
-import useModal from '@/hooks/useModal';
-import { useNotification } from '@/hooks/useNotification';
 import ArticleDetail from '@components/ArticleDetail';
 import ArticleInfoIcon from '@components/ArticleInfoIcon';
 import BackButton from '@components/BackButton';
 import Loader from '@components/Loader';
+import Confirm from '@components/Modals/Confirm';
 import SubButton from '@components/SubButton';
 import { BUTTON, MESSAGE } from '@constants/ArticleDetail';
 import { useArticleDetail } from '@hooks/useArticleDetail';
 import useAuthQuery from '@hooks/useAuthQuery';
 import { useLikeCreateMutation, useLikeDeleteMutation } from '@hooks/useLikeMutation';
+import useModal from '@hooks/useModal';
+import { useNotification } from '@hooks/useNotification';
 import CommentInput from './ArticleDetailPage/CommentInput';
 import Comments from './ArticleDetailPage/Comments';
 
@@ -91,7 +91,7 @@ const ArticleDetailPage = () => {
       )}
       <section className="post-field max-w-[22rem] w-full">
         <div className="flex justify-between">
-          <BackButton onClick={() => navigate(-1)} />
+          <BackButton onClick={() => navigate('/news')} />
           {isMyPost && (
             <div id="isMine" className="flex items-center justify-between w-[3rem]">
               <button

--- a/src/pages/ArticleEditPage.tsx
+++ b/src/pages/ArticleEditPage.tsx
@@ -1,8 +1,8 @@
 import { useLocation, useNavigate } from 'react-router-dom';
-import Confirm from '@/components/Modals/Confirm';
-import { MODAL_MESSAGE } from '@/constants/Messages';
 import CloseButton from '@components/CloseButton';
 import HeaderText from '@components/HeaderText';
+import Confirm from '@components/Modals/Confirm';
+import { MODAL_MESSAGE } from '@constants/Messages';
 import { ETC } from '@constants/NewArticle';
 import useAuthQuery from '@hooks/useAuthQuery';
 import useModal from '@hooks/useModal';
@@ -38,7 +38,7 @@ const ArticleEditPage = () => {
       )}
       <header className="flex flex-col">
         <div className="flex justify-between items-center mb-[1.75rem] ml-[2.44rem] mr-[1.56rem]">
-          <HeaderText size="normal" label={ETC.HEADER_WRITE} />
+          <HeaderText size="normal" label={ETC.HEADER_WRITE_EDIT} />
           <CloseButton onClick={modalOpen} />
         </div>
       </header>

--- a/src/pages/ArticleEditPage.tsx
+++ b/src/pages/ArticleEditPage.tsx
@@ -27,7 +27,7 @@ const ArticleEditPage = () => {
   };
 
   return (
-    <section className="max-w-[25.875rem] mx-auto max-h-[56rem] h-full pt-[2.75rem] position:relative bg-cooled-blue dark:bg-[#303E43] text-tricorn-black dark:text-extra-white font-Cafe24SurroundAir">
+    <section className="max-w-[25.875rem] h-screen mx-auto pt-[2.75rem] position:relative bg-cooled-blue dark:bg-[#303E43] text-tricorn-black dark:text-extra-white font-Cafe24SurroundAir">
       {showModal && (
         <Confirm
           theme="negative"

--- a/src/pages/ArticleEditPage/ArticleEditForm.tsx
+++ b/src/pages/ArticleEditPage/ArticleEditForm.tsx
@@ -122,9 +122,12 @@ const ArticleEditForm = ({
   }, [title, setValue]);
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <div className="flex flex-col h-[48.5rem]  bg-white dark:bg-tricorn-black rounded-t-3xl">
-        <div className="flex items-center justify-between mx-auto w-full max-w-[22.625rem] pt-[2rem]">
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="relative flex flex-col h-full bg-white dark:bg-tricorn-black rounded-t-3xl"
+    >
+      <div>
+        <div className="flex items-center justify-between mx-auto w-full max-w-[22.625rem] pt-[2rem] mb-2">
           <Avatar width={2.5} profileImage={user ? user.image : ''} isLoggedIn={false} />
           <div className="flex w-[12.5rem]">
             <span className="font-Cafe24Surround">{user && user.fullName}</span>
@@ -137,12 +140,12 @@ const ArticleEditForm = ({
           />
         </div>
         <div className="max-w-[22.625rem] mx-auto w-full">
-          <div className="flex items-end justify-center h-[3.5rem] border-b-2 border-cooled-blue">
+          <div className="flex justify-center h-[2.8rem] border-b-2 pb-1 items-end border-cooled-blue gap-2">
             <select
               aria-required
               value={selectedText}
               onChange={handleTitleSelect}
-              className="flex items-center justify-center pb-2 mr-2 text-base outline-none dark:text-extra-white dark:bg-tricorn-black"
+              className="flex items-center justify-center text-base outline-none h-1/2 dark:text-extra-white dark:bg-tricorn-black"
             >
               {DROPDOWN_OPTIONS.map((option, index) => (
                 <option
@@ -168,7 +171,7 @@ const ArticleEditForm = ({
                 },
               })}
               aria-required
-              className="block w-full pb-2 bg-white outline-none dark:bg-tricorn-black"
+              className="block w-full bg-white outline-none h-1/2 dark:bg-tricorn-black"
             />
           </div>
           <div className="flex justify-end w-full">
@@ -181,7 +184,7 @@ const ArticleEditForm = ({
               }`}
             >{`${articleTitle.length}/${LENGTH_LIMIT.TITLE_MAX}`}</span>
           </div>
-          <div className="block">
+          <div className="block h-full">
             {userPreviewImage ? (
               <ImagePreview image={userPreviewImage} onRemove={handleRemoveImage} />
             ) : null}
@@ -226,7 +229,7 @@ const ArticleEditForm = ({
             >{`${articleBody.length}/${LENGTH_LIMIT.CONTENT_MAX}`}</span>
           </div>
         </div>
-        <div className="max-w-[25.875rem] w-full h-[2rem] fixed bottom-4">
+        <div className="max-w-[25.875rem] w-full h-[2rem] bottom-4">
           <label
             htmlFor="file_input"
             className="flex items-center justify-center w-[3.5rem] h-[3.5rem] rounded-full bg-cooled-blue text-white font-Cafe24SurroundAir absolute right-4 bottom-4 shadow-md cursor-pointer"

--- a/src/pages/ArticleEditPage/ImagePreview.tsx
+++ b/src/pages/ArticleEditPage/ImagePreview.tsx
@@ -1,18 +1,30 @@
 import { AiOutlineCloseCircle } from 'react-icons/ai';
 
-const ImagePreview = ({ image, onRemove }: { image: string | null; onRemove?: () => void }) => (
-  <div className="relative inline-block pb-2">
-    <img
-      className="w-[5rem] rounded-lg cursor-pointer drop-shadow-md"
-      src={image !== null ? image : ''}
-      alt="thumbnail"
-      onClick={onRemove}
-    />
-    <AiOutlineCloseCircle
-      size="1rem"
-      className="absolute cursor-pointer text-lazy-gray top-1 right-1"
-    />
-  </div>
-);
+const ImagePreview = ({
+  image,
+  onRemove,
+}: {
+  image: string | File | null | undefined;
+  onRemove?: () => void;
+}) => {
+  const showImage = image !== null && image !== undefined && image !== '';
+
+  return (
+    showImage && (
+      <div className="relative inline-block pb-2">
+        <img
+          className="w-[5rem] rounded-lg cursor-pointer drop-shadow-md"
+          src={image instanceof File ? URL.createObjectURL(image) : image}
+          alt="thumbnail"
+          onClick={onRemove}
+        />
+        <AiOutlineCloseCircle
+          size="1rem"
+          className="absolute cursor-pointer text-lazy-gray top-1 right-1"
+        />
+      </div>
+    )
+  );
+};
 
 export default ImagePreview;

--- a/src/pages/ArticlesPage/RenderArticles.tsx
+++ b/src/pages/ArticlesPage/RenderArticles.tsx
@@ -1,8 +1,5 @@
-import { useNavigate } from 'react-router-dom';
 import { Post } from '@type/Post';
 import Article from '@components/Article';
-import SubButton from '@components/SubButton';
-import { API } from '@constants/Article';
 import { filterArticles } from './filterArticles';
 
 type ArticlesProps = {
@@ -10,26 +7,7 @@ type ArticlesProps = {
 };
 
 const RenderArticles = ({ articles }: ArticlesProps) => {
-  const navigate = useNavigate();
-
   const filteredArticles = filterArticles(articles);
-  const isArticlesEmpty = filteredArticles && filteredArticles.length === 0;
-
-  if (isArticlesEmpty) {
-    return (
-      <div className="flex flex-col items-center justify-center w-full gap-4 mx-auto mt-4">
-        <span className="text-center">앗, 팔로우한 사람들의 글 목록이 존재하지 않습니다!</span>
-        <div
-          className="inline-block mx-auto"
-          onClick={() => {
-            navigate(`${API.SEARCH_URL}`);
-          }}
-        >
-          <SubButton size="small" color="blue" label="팔로우 하러 가기" type="outline" />
-        </div>
-      </div>
-    );
-  }
 
   return filteredArticles?.map((article) => {
     const { _id, title, author, createdAt, likes, image, comments } = article;

--- a/src/pages/ArticlesPage/RenderFollowingArticles.tsx
+++ b/src/pages/ArticlesPage/RenderFollowingArticles.tsx
@@ -1,18 +1,21 @@
 import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import Loader from '@/components/Loader';
-import { ARTICLE_FETCH_LIMIT } from '@/constants/Article';
-import { TAB_CONSTANTS } from '@/constants/Tab';
-import useAuthQuery from '@/hooks/useAuthQuery';
+import SubButton from '@/components/SubButton';
+import Loader from '@components/Loader';
+import { API, ARTICLE_FETCH_LIMIT } from '@constants/Article';
+import { TAB_CONSTANTS } from '@constants/Tab';
+import useAuthQuery from '@hooks/useAuthQuery';
 import { fetchArticles } from './fetchArticles';
 import InfiniteScroll from './InfiniteScroll';
 import RenderArticles from './RenderArticles';
 
 const RenderFollowingArticles = () => {
   const {
-    userQuery: { data: user },
+    userQuery: { data: user, isLoading: userLoading },
   } = useAuthQuery();
 
+  const navigate = useNavigate();
   const followingUsersIds = Array.from(new Set(user?.following.map((user) => user.user)));
 
   const fetchFollowing = useCallback(
@@ -26,8 +29,8 @@ const RenderFollowingArticles = () => {
     [followingUsersIds],
   );
 
-  const { data, fetchNextPage, hasNextPage, isLoading, isFetching } = useInfiniteQuery(
-    ['followingArticles', followingUsersIds],
+  const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery(
+    ['followingArticles', [...followingUsersIds]],
     fetchFollowing,
     {
       getNextPageParam: (lastPage, pages) => {
@@ -41,20 +44,29 @@ const RenderFollowingArticles = () => {
 
   return (
     <>
-      {isLoading ? (
+      {userLoading ? (
         <div className="flex justify-center">
           <Loader />
         </div>
       ) : (
         <>
-          {data?.pages.flat().length === 0 && (
-            <div className="flex flex-col items-center justify-center w-full gap-4 mx-auto mt-4">
-              <span className="text-center">
-                앗, 팔로우한 사람들의 글 목록이 존재하지 않습니다!
+          {!data?.pages || data?.pages.flat().length === 0 ? (
+            <div className="flex flex-col items-center justify-center w-2/3 h-full gap-4 mx-auto">
+              <span className="block text-center font-Cafe24SurroundAir">
+                앗, 팔로우한 사람들의 <br />글 목록이 존재하지 않습니다!
               </span>
+              <div
+                className="inline-block mx-auto"
+                onClick={() => {
+                  navigate(`${API.SEARCH_URL}`);
+                }}
+              >
+                <SubButton size="small" color="blue" label="팔로우 하러 가기" type="outline" />
+              </div>
             </div>
+          ) : (
+            <RenderArticles articles={data?.pages.flat() || []} />
           )}
-          <RenderArticles articles={data?.pages.flat() || []} />
           {isFetching && (
             <div className="flex justify-center">
               <Loader />

--- a/src/pages/NewArticlePage.tsx
+++ b/src/pages/NewArticlePage.tsx
@@ -90,7 +90,7 @@ const NewArticlePage = () => {
   };
 
   return (
-    <div className="max-w-[25.875rem] mx-auto h-screen pt-[2.75rem] position:relative bg-cooled-blue dark:bg-[#303E43] text-tricorn-black dark:text-extra-white font-Cafe24SurroundAir">
+    <div className="max-w-[25.875rem] mx-auto h-screen pt-[2.75rem] relative bg-cooled-blue dark:bg-[#303E43] text-tricorn-black dark:text-extra-white font-Cafe24SurroundAir">
       <header className="flex flex-col">
         <div className="flex justify-between items-center mb-[1.75rem] ml-[2.44rem] mr-[1.56rem]">
           <HeaderText size="normal" label={ETC.HEADER_WRITE} />
@@ -99,7 +99,7 @@ const NewArticlePage = () => {
       </header>
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="flex flex-col h-screen bg-white dark:bg-tricorn-black rounded-t-3xl">
-          <div className="flex items-center justify-between mx-auto w-full max-w-[22.625rem] pt-[2rem]">
+          <div className="flex items-center justify-between mx-auto w-full max-w-[22.625rem] pt-[2rem] mb-2">
             <Avatar
               width={2.5}
               profileImage={profileImage ? profileImage : ''}
@@ -116,18 +116,18 @@ const NewArticlePage = () => {
             />
           </div>
           <div className="max-w-[22.625rem] mx-auto w-full">
-            <div className="flex justify-center items-end h-[3.5rem] border-b-2 border-cooled-blue">
+            <div className="flex justify-center h-[2.8rem] border-b-2 pb-1 items-end border-cooled-blue gap-2">
               <select
                 aria-required
                 value={selectedText}
                 onChange={handleTitleSelect}
-                className="flex justify-center items-center pb-2 mr-2 outline-none text-base dark:text-extra-white dark:bg-tricorn-black"
+                className="flex items-center justify-center text-base outline-none h-1/2 dark:text-extra-white dark:bg-tricorn-black"
               >
                 {DROPDOWN_OPTIONS.map((option, index) => (
                   <option
                     key={index}
                     value={option}
-                    className="align-middle text-center"
+                    className="text-center align-middle"
                     disabled={option === DROPDOWN_OPTIONS[0]}
                   >
                     {option}
@@ -147,12 +147,12 @@ const NewArticlePage = () => {
                   },
                 })}
                 placeholder={MESSAGE.TITLE_REQUIRED}
-                className="block w-full pb-2 outline-none bg-white dark:bg-tricorn-black"
+                className="block w-full bg-white outline-none h-1/2 dark:bg-tricorn-black"
               />
             </div>
             <div className="flex justify-end w-full">
               {errors?.title && (
-                <span className="text-xs text-error-red mr-3">{errors.title.message}</span>
+                <span className="mr-3 text-xs text-error-red">{errors.title.message}</span>
               )}
               <span
                 className={`text-xs ${
@@ -162,7 +162,7 @@ const NewArticlePage = () => {
             </div>
             <div className="block">
               {image && (
-                <div className="inline-block pb-2 relative">
+                <div className="relative inline-block pb-2">
                   <img
                     className="w-[5rem] rounded-lg cursor-pointer drop-shadow-md"
                     src={URL.createObjectURL(image)}
@@ -171,7 +171,7 @@ const NewArticlePage = () => {
                   />
                   <AiOutlineCloseCircle
                     size="1rem"
-                    className="text-lazy-gray absolute top-1 right-1 cursor-pointer"
+                    className="absolute cursor-pointer text-lazy-gray top-1 right-1"
                     onClick={handleRemoveImage}
                   />
                 </div>
@@ -190,11 +190,10 @@ const NewArticlePage = () => {
                   },
                 })}
                 placeholder={MESSAGE.CONTENT_REQUIRED}
-                maxLength={LENGTH_LIMIT.CONTENT_MAX}
-                className="overflow-hidden outline-none resize-none h-auto w-full bg-white dark:bg-tricorn-black"
+                className="w-full h-auto overflow-hidden bg-white outline-none resize-none dark:bg-tricorn-black"
               />
               {errors?.body && (
-                <span className="text-xs text-error-red mr-3">{errors.body.message}</span>
+                <span className="mr-3 text-xs text-error-red">{errors.body.message}</span>
               )}
               <span
                 className={`text-xs ${
@@ -205,7 +204,7 @@ const NewArticlePage = () => {
               >{`${articleBody.length}/${LENGTH_LIMIT.CONTENT_MAX}`}</span>
             </div>
           </div>
-          <div className="max-w-[25.875rem] w-full h-[2rem] fixed bottom-4">
+          <div className="max-w-[25.875rem] w-full h-[2rem]">
             <label
               htmlFor="file_input"
               className="flex items-center justify-center w-[3.5rem] h-[3.5rem] rounded-full bg-cooled-blue text-white font-Cafe24SurroundAir absolute right-4 bottom-4 shadow-md cursor-pointer"

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -7,7 +7,6 @@ import { IoSettingsSharp } from 'react-icons/io5';
 import { fetchUser } from '@api/common/User';
 import BackButton from '@components/BackButton';
 import BottomNavigation from '@components/BottomNavigation';
-import Loader from '@components/Loader';
 import ScrollToTopButton from '@components/ScrollToTopButton';
 import SubscribeInfo from '@components/SubscribeInfo';
 import Tab from '@components/Tab';
@@ -33,7 +32,9 @@ const ProfilePage = () => {
     userQuery: { data: user },
     logoutQuery: { mutate: logoutMutate },
   } = useAuthQuery();
-  const { data: userInfo } = useQuery(['userInfo', lastSegment], () => fetchUser(lastSegment));
+  const { data: userInfo, isLoading: userInfoLoading } = useQuery(['userInfo', lastSegment], () =>
+    fetchUser(lastSegment),
+  );
 
   const { showToast } = useToastContext();
 
@@ -87,42 +88,38 @@ const ProfilePage = () => {
           </div>
           <div className="flex justify-center pb-8 mb-[1.2rem] border-b-[0.01rem] border-tertiory-gray relative">
             <div className="flex flex-col items-center">
-              <div className="relative self-center w-32 h-32 mb-6 border rounded-full bg-profile-bg border-tertiory-gray text-footer-icon">
-                {userInfo ? (
-                  <img
-                    src={userInfo.image}
-                    className="w-full h-full rounded-full object-cover"
-                    alt="thumbnail"
-                  />
-                ) : (
-                  <BiSolidUser className="w-24 h-24 translate-x-4 translate-y-4" />
-                )}
-                {isMyProfile && (
-                  <>
-                    <label
-                      htmlFor="image"
-                      className="absolute p-1 border rounded-full right-1 bottom-1 bg-profile-bg border-tertiory-gray"
-                    >
-                      {userImageMutation.isLoading ? (
-                        <div className="w-4 h-4">
-                          <Loader size="xs" />
-                        </div>
-                      ) : (
-                        <HiPencil className="w-4 h-4" />
-                      )}
-                    </label>
-                    <input
-                      type="file"
-                      accept="image/*"
-                      className="hidden"
-                      id="image"
-                      onChange={handleUploadImage}
+              {!userInfoLoading && (
+                <div className="relative self-center w-32 h-32 mb-6 border rounded-full bg-profile-bg border-tertiory-gray text-footer-icon">
+                  {userInfo && userInfo.image ? (
+                    <img
+                      src={userInfo.image}
+                      className="object-cover w-full h-full rounded-full "
+                      alt="thumbnail"
                     />
-                  </>
-                )}
-              </div>
+                  ) : (
+                    <BiSolidUser className="w-24 h-24 translate-x-4 translate-y-4" />
+                  )}
+                  {isMyProfile && (
+                    <>
+                      <label
+                        htmlFor="image"
+                        className="absolute p-1 border rounded-full right-1 bottom-1 bg-profile-bg border-tertiory-gray"
+                      >
+                        <HiPencil className="w-4 h-4" />
+                      </label>
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        id="image"
+                        onChange={handleUploadImage}
+                      />
+                    </>
+                  )}
+                </div>
+              )}
               <div className="flex items-center mt-2 mb-[0.3rem]">
-                <span className="text-center  h-[1.8125rem] font-Cafe24Surround text-[1.375rem] -tracking-[0.01875rem] mr-2">
+                <span className="text-center h-[1.8125rem] font-Cafe24Surround text-[1.375rem] -tracking-[0.01875rem] mr-2">
                   {userInfo?.fullName}
                 </span>
                 <span className="text-center max-w-[1.6875rem] h-[1.125rem] text-[0.875rem] text-lazy-gray">
@@ -176,8 +173,8 @@ const ProfilePage = () => {
             {userInfo && userInfo.posts.length > 0 ? (
               <UserArticles userId={userInfo._id} />
             ) : (
-              <div className="flex justify-center">
-                <span className="text-center text-lazy-gray">
+              <div className="flex justify-center w-full h-full">
+                <span className="flex items-center justify-center text-center text-lazy-gray">
                   {TAB_CONSTANTS.WRITTEN_ARTICLES}가 없습니다.
                 </span>
               </div>
@@ -187,8 +184,8 @@ const ProfilePage = () => {
             {likeArticlesIds && likeArticlesIds.length > 0 ? (
               <LikedArticles postIds={likeArticlesIds} />
             ) : (
-              <div className="flex justify-center">
-                <span className="text-center text-lazy-gray">
+              <div className="flex justify-center w-full h-full">
+                <span className="flex items-center justify-center text-center text-lazy-gray">
                   {TAB_CONSTANTS.LIKED_ARTICLES}가 없습니다.
                 </span>
               </div>

--- a/src/pages/ProfilePage/LikeArticles.tsx
+++ b/src/pages/ProfilePage/LikeArticles.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import fetchArticleById from '@api/fetchArticleById';
+import Loader from '@components/Loader';
 import RenderArticles from '../ArticlesPage/RenderArticles';
 
 const LikedArticles = ({ postIds }: { postIds: string[] }) => {
@@ -10,7 +11,7 @@ const LikedArticles = ({ postIds }: { postIds: string[] }) => {
 
   const { data: allFetchedArticles } = useQuery(['articles', postIds], fetchMultipleArticles);
 
-  return allFetchedArticles ? <RenderArticles articles={allFetchedArticles} /> : null;
+  return allFetchedArticles ? <RenderArticles articles={allFetchedArticles} /> : <Loader />;
 };
 
 export default LikedArticles;

--- a/src/pages/ProfilePage/UserArticles.tsx
+++ b/src/pages/ProfilePage/UserArticles.tsx
@@ -1,3 +1,4 @@
+import Loader from '@components/Loader';
 import { useArticles } from '@hooks/useArticles';
 import RenderArticles from '../ArticlesPage/RenderArticles';
 
@@ -11,7 +12,7 @@ const UserArticles = ({ userId }: UserArticlesProps) => {
     type: 'user',
   });
 
-  return isLoading ? null : <RenderArticles articles={userArticles} />;
+  return isLoading ? <Loader /> : <RenderArticles articles={userArticles} />;
 };
 
 export default UserArticles;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #232 

## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 게시글 작성, 수정 페이지의 UI를 통일하였습니다.
- 게시글 수정 페이지에서 이미지를 업데이트할 때 발생하던 에러를 수정했습니다.
- 게시글 제목 prefix를 split해서 select의 option 값으로 설정해주도록 구현했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

- 게시글 수정 페이지에서 이미지 업데이트

![ezgif com-video-to-gif (6)](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43228743/08ca6492-0ac1-4e55-b9af-bfd5cdec2229)

- 게시글 제목의 prefix가 없으면 에러 토스트를 띄우도록 수정

![ezgif com-video-to-gif (7)](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43228743/3b34e028-0c3c-4477-bb45-83aedaac32a5)

- 팔로우 탭 레이아웃 수정
![ezgif com-video-to-gif (10)](https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/43228743/1d7ee6f3-deda-40e8-ada8-46f2f8b73eae)

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

