### PR TITLE
fix: 다크모드 사용자 컬러모드로 초기 설정

### DIFF
--- a/src/components/DarkMode.tsx
+++ b/src/components/DarkMode.tsx
@@ -1,35 +1,36 @@
 import { useEffect, useState } from 'react';
 
 const DarkMode = () => {
-  const [isDark, setIsDark] = useState(false);
+  const [mode, setMode] = useState(localStorage.getItem('theme') || 'light');
+  const isSavedTheme = localStorage.getItem('theme');
 
   const toggleDarkMode = () => {
-    if (localStorage.getItem('theme') === 'dark') {
-      localStorage.removeItem('theme');
+    if (mode === 'dark') {
+      localStorage.setItem('theme', 'light');
+      setMode('light');
       document.documentElement.classList.remove('dark');
-      setIsDark(false);
     } else {
-      document.documentElement.classList.add('dark');
       localStorage.setItem('theme', 'dark');
-      setIsDark(true);
+      setMode('dark');
+      document.documentElement.classList.add('dark');
     }
   };
 
   useEffect(() => {
-    if (
-      localStorage.theme === 'dark' ||
-      (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
-    ) {
-      document.documentElement.classList.add('dark');
-      setIsDark(true);
+    const preferredTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+
+    if (isSavedTheme !== null) {
+      setMode(isSavedTheme);
     } else {
-      document.documentElement.classList.remove('dark');
-      setIsDark(false);
+      localStorage.setItem('theme', preferredTheme);
+      setMode(preferredTheme);
     }
-  }, []);
+  }, [isSavedTheme]);
 
   return (
-    <label className={`swap swap-rotate ${isDark ? 'swap-off' : 'swap-on'}`}>
+    <label className={`swap swap-rotate ${mode === 'dark' ? 'swap-on' : 'swap-off'}`}>
       <input type="checkbox" onClick={toggleDarkMode} />
       <svg
         className="swap-on fill-tricorn-black dark:fill-white w-[1.5rem] h-[1.5rem]"


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #252 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 사용자 컬러 모드를 받아 와서 바로 localStorage에 세팅합니다.
- 토글버튼을 누름에 따라 localStorage에 theme의 값이 변경됩니다. 
- 다크모드일 때는 햇님 아이콘, 라이트모드일 때는 달 아이콘입니다. 

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
