### PR TITLE
refactor: 댓글 삭제 시 상세 페이지 반영 + 댓글 오류 메시지 삭제 + 제출 중 버튼 비활성화

### DIFF
--- a/src/components/MainButton.tsx
+++ b/src/components/MainButton.tsx
@@ -7,6 +7,7 @@ type MainButtonProps = {
   onClick?: VoidFunction;
   isLoading?: boolean;
   className?: string;
+  disabled?: boolean;
 };
 
 const BASE_BUTTON_CLASSES = 'rounded-md text-base w-[18.375rem] h-[3.125rem]';

--- a/src/hooks/useArticleDetail.tsx
+++ b/src/hooks/useArticleDetail.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Post } from '@type/Post';
-import { CommentParams, createComment } from '@/api/common/Comment';
+import { CommentParams, createComment, deleteComment } from '@/api/common/Comment';
 import { createNotification } from '@/api/common/Notification';
 import { deletePost, fetchPost } from '@/api/common/Post';
 import { TOAST_MESSAGES } from '@/constants/Messages';
@@ -67,5 +67,20 @@ export const useArticleDetail = () => {
     commentMutation.mutate(newComment);
   };
 
-  return { data, isLoading, addComment, deletePostArticle };
+  const deleteCommentMutation = useMutation(deleteComment, {
+    onSuccess: () => {
+      Promise.all([
+        queryClient.invalidateQueries(['article', postId]),
+        queryClient.invalidateQueries(['articles']),
+        queryClient.invalidateQueries(['newestArticles']),
+      ]);
+      showToast('댓글이 삭제되었습니다', 'success');
+    },
+  });
+
+  const deleteMyComment = (commentId: string) => {
+    deleteCommentMutation.mutate(commentId);
+  };
+
+  return { data, isLoading, addComment, deletePostArticle, deleteMyComment };
 };

--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -151,7 +151,7 @@ const ArticleDetailPage = () => {
       <section>
         {comments.length === 0 ? (
           <div className="flex justify-start w-[22rem] mt-[3%]">
-            <span className="text-xs text-gray-400">{MESSAGE.NO_COMMENT}</span>
+            <span className="text-xs text-gray-400 ">{MESSAGE.NO_COMMENT}</span>
           </div>
         ) : (
           <div className="mb-[6rem]">

--- a/src/pages/ArticleDetailPage/CommentInput.tsx
+++ b/src/pages/ArticleDetailPage/CommentInput.tsx
@@ -27,7 +27,7 @@ const CommentInput = ({
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { isSubmitting },
     reset,
   } = useForm<FormValueType>();
 
@@ -63,14 +63,11 @@ const CommentInput = ({
             />
           </div>
           <div className="flex items-center justify-center">
-            <button className="outline-none cursor-pointer">
+            <button className="outline-none cursor-pointer" disabled={isSubmitting}>
               <RiQuillPenFill className="fill-cooled-blue w-[1.5rem] h-[1.5rem]" />
             </button>
           </div>
         </div>
-        {errors?.comment && (
-          <span className="text-xs text-error-red">{errors.comment.message}</span>
-        )}
       </form>
     </div>
   );

--- a/src/pages/ArticleDetailPage/Comments.tsx
+++ b/src/pages/ArticleDetailPage/Comments.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Comment as CommentType } from '@type/Comment';
-import { deleteComment } from '@/api/common/Comment';
 import Comment from '@components/Comment';
+import { useArticleDetail } from '@hooks/useArticleDetail';
 
 type CommentsProps = {
   comments: CommentType[];
@@ -10,16 +10,10 @@ type CommentsProps = {
 
 const Comments = ({ comments, userId }: CommentsProps) => {
   const [commentList, setCommentList] = useState<CommentType[]>(comments);
+  const { deleteMyComment } = useArticleDetail();
 
-  const handleDeleteComment = async (commentId: string) => {
-    try {
-      await deleteComment(commentId);
-      const updatedComments = commentList.filter((comment) => comment._id !== commentId);
-      setCommentList(updatedComments);
-      alert('댓글 삭제 완료');
-    } catch (error) {
-      alert(error);
-    }
+  const handleDeleteComment = (commentId: string) => {
+    deleteMyComment(commentId);
   };
 
   useEffect(() => {
@@ -42,7 +36,7 @@ const Comments = ({ comments, userId }: CommentsProps) => {
           active={isMyComment}
           authorId={authorId}
           profileImage={authorImage ? authorImage : ''}
-          onDelete={(commentId) => handleDeleteComment(commentId)}
+          onDelete={handleDeleteComment}
         />
       );
     } catch (error) {

--- a/src/pages/NewArticlePage.tsx
+++ b/src/pages/NewArticlePage.tsx
@@ -115,6 +115,7 @@ const NewArticlePage = () => {
               type="submit"
               label={ETC.BUTTON_WRITE}
               isLoading={isLoading}
+              disabled={isLoading}
             />
           </div>
           <div className="max-w-[22.625rem] w-[90%] mx-auto">


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #255 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 댓글 삭제 시 상세 페이지에 바로 반영 됩니다. 
- 하나뿐인 댓글 삭제 시 바로 '댓글이 없습니다'를 보여줍니다.
- 댓글 오류 메시지를 삭제했습니다.
- 댓글 작성 후 제출 중에는 작성버튼이 비활성화 됩니다.

- 글 작성 후 제출 중에는 작성버튼이 비활성화 됩니다. 

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
