### PR TITLE
refactor: 뜨거운뉴스 좋아요+토스트 수정

### DIFF
--- a/src/pages/ArticleDetailPage.tsx
+++ b/src/pages/ArticleDetailPage.tsx
@@ -13,6 +13,7 @@ import useAuthQuery from '@hooks/useAuthQuery';
 import { useLikeCreateMutation, useLikeDeleteMutation } from '@hooks/useLikeMutation';
 import useModal from '@hooks/useModal';
 import { useNotification } from '@hooks/useNotification';
+import { useToastContext } from '@hooks/useToastContext';
 import CommentInput from './ArticleDetailPage/CommentInput';
 import Comments from './ArticleDetailPage/Comments';
 import { LoadingPage } from '.';
@@ -21,6 +22,7 @@ const ArticleDetailPage = () => {
   const navigate = useNavigate();
   const { showModal, modalOpen, modalClose } = useModal();
   const [isImageLoaded, setIsImageLoaded] = useState(false);
+  const { showToast } = useToastContext();
 
   const {
     userQuery: { data: user },
@@ -66,7 +68,7 @@ const ArticleDetailPage = () => {
       return;
     }
     if (!isLoginUser) {
-      alert('로그인 후에 누를 수 있습니다!');
+      showToast('로그인이 필요해요');
     } else {
       toggleLikeMutate();
     }

--- a/src/pages/ArticlesPage.tsx
+++ b/src/pages/ArticlesPage.tsx
@@ -38,7 +38,7 @@ const ArticlesPage = () => {
           <div className="flex justify-between items-center mb-[1.75rem] ml-[2.44rem] mr-[1.56rem]">
             <HeaderText label="뉴스" />
             <MdOutlineSearch
-              className="w-[1.8rem] h-[1.8rem] cursor-pointer"
+              className="w-[1.8rem] h-[1.8rem] cursor-pointer text-tricorn-black dark:text-extra-white"
               onClick={() => {
                 navigate('/search');
               }}

--- a/src/pages/HomePage/HotArticles.tsx
+++ b/src/pages/HomePage/HotArticles.tsx
@@ -3,12 +3,16 @@ import { Post } from '@type/Post';
 import SubButton from '@/components/SubButton';
 import { ROUTES } from '@/constants/Article';
 import Article from '@components/Article';
+import useAuthQuery from '@hooks/useAuthQuery';
 
 type ArticlesProps = {
   articles: Post[];
 };
 
 const HotArticles = ({ articles }: ArticlesProps) => {
+  const {
+    userQuery: { data: user },
+  } = useAuthQuery();
   const navigate = useNavigate();
   const isArticlesEmpty = articles && articles.length === 0;
 
@@ -32,6 +36,7 @@ const HotArticles = ({ articles }: ArticlesProps) => {
   return articles?.map((article) => {
     const { _id, title, author, createdAt, likes, image, comments } = article;
     const { fullName } = author;
+    const myLike = likes.find((like) => (user ? like.user === user._id : false));
     try {
       const { title: articleTitle } = JSON.parse(title);
       return (
@@ -45,6 +50,7 @@ const HotArticles = ({ articles }: ArticlesProps) => {
           hasImage={image !== undefined}
           likes={likes?.length || 0}
           comments={comments?.length || 0}
+          myLikeArticle={!!myLike}
         />
       );
     } catch (e) {

--- a/src/pages/NotificationPage/NoticeList.tsx
+++ b/src/pages/NotificationPage/NoticeList.tsx
@@ -1,4 +1,4 @@
-import { AiOutlineBell } from 'react-icons/ai';
+import { BsBell } from 'react-icons/bs';
 import Notice from '@/components/Notice';
 import type { Notification } from '@/type/Notification';
 import { getTimeDelta } from '@/utils/getTimeDelta';
@@ -40,7 +40,7 @@ const NoNotification = () => {
   return (
     <div className="flex flex-col items-center w-full max-w-[22.625rem] justify-center flex-grow gap-4">
       <div className="w-20 h-20 rounded-full bg-cooled-blue">
-        <AiOutlineBell className="w-10 h-10 text-white translate-x-1/2 translate-y-1/2" />
+        <BsBell className="w-10 h-10 text-white translate-x-1/2 translate-y-1/2" />
       </div>
       <p className="text-2xl font-light text-wall-street font-Cafe24SurroundAir">알림이 없어요</p>
     </div>


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #289
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

- [x] 홈페이지에 뜨거운 뉴스에 있는 게시글을 좋아요했을때 따봉버튼의 색깔을 변경했습니다.
- [x] 뉴스 검색 아이콘의 색상을 변경했습니다.
- [x] 알림페이지에 알림 아이콘을 바텀네비에있는 아이콘과 통일했습니다.
- [x] 비회원일시 응원하기버튼을 누르면 토스트가 뜨도록 했습니다. => 모달로 하려다가 페이지내에서 이미 모달을 사용하고있어서 토스트로 했습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
## 📖 PR 포인트 & 궁금한 점 <!-- 리

https://github.com/prgrms-fe-devcourse/FEDC4_TMI_HOMERS_OFF/assets/104294861/2173f306-9c77-4654-8438-5dce04b4df68

뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
