### PR TITLE
feat: 프로필 페이지 구독, 구독취소 버튼 구현

### DIFF
--- a/src/constants/Messages.ts
+++ b/src/constants/Messages.ts
@@ -23,6 +23,8 @@ export const TOAST_MESSAGES = {
 
   FOLLOW_SUCCESS: '구독되었어요.',
   FOLLOW_FAILED: '구독 요청에 실패했어요.',
+  UNFOLLOW_SUCCESS: '구독이 취소되었어요.',
+  UNFOLLOW_FAILED: '구독 취소 요청에 실패했어요.',
 
   EDIT_PROFILE_SUCCESS: '회원정보가 수정되었어요.',
   EDIT_PROFILE_FAILED: '회원정보 수정 도중 오류가 발생했어요.',

--- a/src/hooks/useFollowQuery.tsx
+++ b/src/hooks/useFollowQuery.tsx
@@ -1,9 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { User } from '@type/User';
+import { TOAST_MESSAGES } from '@/constants/Messages';
 import { followUser, unFollowUser } from '@api/common/Follow';
 import { createNotification } from '@api/common/Notification';
+import { useToastContext } from './useToastContext';
+
 const useFollowQuery = () => {
   const queryClient = useQueryClient();
+  const { showToast } = useToastContext();
 
   const followMutation = useMutation(followUser, {
     onMutate: async (id) => {
@@ -20,6 +24,7 @@ const useFollowQuery = () => {
       if (context) {
         queryClient.setQueryData(['user'], context);
       }
+      showToast(TOAST_MESSAGES.FOLLOW_FAILED, 'error');
     },
     onSettled: () => {
       Promise.all([
@@ -28,6 +33,7 @@ const useFollowQuery = () => {
       ]);
     },
     onSuccess: (data) => {
+      showToast(TOAST_MESSAGES.FOLLOW_SUCCESS, 'success');
       createNotification({
         notificationTypeId: data._id,
         notificationType: 'FOLLOW',
@@ -49,6 +55,7 @@ const useFollowQuery = () => {
       return preData;
     },
     onError: (_, __, context) => {
+      showToast(TOAST_MESSAGES.UNFOLLOW_FAILED, 'error');
       if (context) {
         queryClient.setQueryData(['user'], context);
       }
@@ -58,6 +65,9 @@ const useFollowQuery = () => {
         queryClient.invalidateQueries(['user']),
         queryClient.invalidateQueries(['followingArticles']),
       ]);
+    },
+    onSuccess: () => {
+      showToast(TOAST_MESSAGES.UNFOLLOW_SUCCESS, 'success');
     },
   });
 

--- a/src/hooks/useFollowQuery.tsx
+++ b/src/hooks/useFollowQuery.tsx
@@ -26,9 +26,10 @@ const useFollowQuery = () => {
       }
       showToast(TOAST_MESSAGES.FOLLOW_FAILED, 'error');
     },
-    onSettled: () => {
+    onSettled: (data) => {
       Promise.all([
         queryClient.invalidateQueries(['user']),
+        queryClient.invalidateQueries(['userInfo', data?.user]),
         queryClient.invalidateQueries(['followingArticles']),
       ]);
     },
@@ -60,9 +61,10 @@ const useFollowQuery = () => {
         queryClient.setQueryData(['user'], context);
       }
     },
-    onSettled: () => {
+    onSettled: (data) => {
       Promise.all([
         queryClient.invalidateQueries(['user']),
+        queryClient.invalidateQueries(['userInfo', data?.user]),
         queryClient.invalidateQueries(['followingArticles']),
       ]);
     },

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -3,7 +3,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { User } from '@type/User';
 import { BiSolidUser } from 'react-icons/bi';
-import { BsBookmarkStarFill, BsBookmarkPlus } from 'react-icons/bs';
+// import { MdStars } from 'react-icons/md';
+import { BsBookmarkStarFill, BsBookmarkStar } from 'react-icons/bs';
 import { HiPencil } from 'react-icons/hi';
 import { IoSettingsSharp } from 'react-icons/io5';
 import { fetchUser } from '@api/common/User';
@@ -67,19 +68,26 @@ const ProfilePage = () => {
       }
     };
 
-    const ICON_CLASS = {
+    const ALTS = {
+      UNFOLLOW: '구독취소하기',
+      FOLLOW: '구독하기',
+    };
+
+    const BUTTON_CLASS = {
+      CONTAINER_CLASS: 'transform transition duration-100 active:scale-90',
       FOLLOW_ICON:
-        'fill-wall-street hover:fill-cooled-blue active:fill-cooled-blue transform transition duration-100 active:scale-90',
-      UNFOLLOW_ICON:
-        'fill-light-violet hover:fill-cooled-blue active:fill-cooled-blue transform transition duration-100 active:scale-90',
+        'fill-wall-street dark:fill-extra-white hover:fill-cooled-blue active:fill-cooled-blue',
+      UNFOLLOW_ICON: 'fill-light-violet hover:fill-cooled-blue active:fill-cooled-blue',
     };
     return (
-      <div onClick={handleToggleFollow} className="text-[1.7rem] cursor-pointer self-end">
-        {isFollowing(user) ? (
-          <BsBookmarkStarFill className={ICON_CLASS.UNFOLLOW_ICON} alt="구독취소" />
-        ) : (
-          <BsBookmarkPlus className={ICON_CLASS.FOLLOW_ICON} alt="구독하기" />
-        )}
+      <div onClick={handleToggleFollow} className="text-[1.7rem] cursor-pointer self-end flex">
+        <div className={BUTTON_CLASS.CONTAINER_CLASS}>
+          {isFollowing(user) ? (
+            <BsBookmarkStarFill className={BUTTON_CLASS.UNFOLLOW_ICON} alt={ALTS.UNFOLLOW} />
+          ) : (
+            <BsBookmarkStar className={BUTTON_CLASS.FOLLOW_ICON} alt={ALTS.FOLLOW} />
+          )}
+        </div>
       </div>
     );
   };

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,7 +1,9 @@
 import { ChangeEvent, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { User } from '@type/User';
 import { BiSolidUser } from 'react-icons/bi';
+import { BsBookmarkStarFill, BsBookmarkPlus } from 'react-icons/bs';
 import { HiPencil } from 'react-icons/hi';
 import { IoSettingsSharp } from 'react-icons/io5';
 import { fetchUser } from '@api/common/User';
@@ -15,6 +17,7 @@ import TabItem from '@components/TabItem';
 import { CURRENT_PROFILE_TAB_KEY, TAB_CONSTANTS, TOTAL_TAB_WIDTH } from '@constants/Tab';
 import { TabContextProvider } from '@context/TabContext';
 import useAuthQuery from '@hooks/useAuthQuery';
+import useFollowQuery from '@hooks/useFollowQuery';
 import useImageMutation from '@hooks/useImageMutation';
 import useModal from '@hooks/useModal';
 import useScrollToTop from '@hooks/useScrollToTop';
@@ -31,8 +34,11 @@ const CHANGE_PASSWORD_PAGE_URL = '/password';
 const ProfilePage = () => {
   const location = useLocation();
   const navigate = useNavigate();
+
   const pathSegments = location.pathname.split('/');
   const lastSegment = pathSegments[pathSegments.length - 1];
+  const profileId = pathSegments[2];
+
   const {
     userQuery: { data: user },
     logoutQuery: { mutate: logoutMutate },
@@ -40,6 +46,43 @@ const ProfilePage = () => {
   const { data: userInfo, isLoading: userInfoLoading } = useQuery(['userInfo', lastSegment], () =>
     fetchUser(lastSegment),
   );
+
+  const FollowButton = () => {
+    const { followMutation, unFollowMutation } = useFollowQuery();
+
+    const handleToggleFollow = () => {
+      if (user) {
+        const followingUserId = user.following.find(({ user }) => user === profileId);
+        if (!followingUserId) {
+          followMutation.mutate(profileId);
+        } else {
+          unFollowMutation.mutate(followingUserId._id);
+        }
+      }
+    };
+
+    const isFollowing = (user: User | undefined | null) => {
+      if (user) {
+        return user.following.some(({ user }) => user === profileId) ?? false;
+      }
+    };
+
+    const ICON_CLASS = {
+      FOLLOW_ICON:
+        'fill-wall-street hover:fill-cooled-blue active:fill-cooled-blue transform transition duration-100 active:scale-90',
+      UNFOLLOW_ICON:
+        'fill-light-violet hover:fill-cooled-blue active:fill-cooled-blue transform transition duration-100 active:scale-90',
+    };
+    return (
+      <div onClick={handleToggleFollow} className="text-[1.7rem] cursor-pointer self-end">
+        {isFollowing(user) ? (
+          <BsBookmarkStarFill className={ICON_CLASS.UNFOLLOW_ICON} alt="구독취소" />
+        ) : (
+          <BsBookmarkPlus className={ICON_CLASS.FOLLOW_ICON} alt="구독하기" />
+        )}
+      </div>
+    );
+  };
 
   const { showToast } = useToastContext();
 
@@ -121,6 +164,7 @@ const ProfilePage = () => {
               }}
             />
             {isMyProfile && <SettingsDropdown />}
+            {!isMyProfile && <FollowButton />}
           </div>
           <div className="flex justify-center pb-8 mb-[1.2rem] border-b-[0.01rem] border-tertiory-gray relative">
             <div className="flex flex-col items-center">

--- a/src/pages/SearchPage/UserListItem.tsx
+++ b/src/pages/SearchPage/UserListItem.tsx
@@ -8,7 +8,6 @@ import { ARTICLE_TITLE_MAX_LENGTH } from '@constants/Article';
 import useAuthQuery from '@hooks/useAuthQuery';
 import useFollowQuery from '@hooks/useFollowQuery';
 import useModal from '@hooks/useModal';
-import { useToastContext } from '@hooks/useToastContext';
 
 const SEARCH_RESULT_CLASS =
   'cursor-pointer max-w-[22.375rem] mb-[0.8rem] mt-[1rem] mx-auto flex items-center justify-between font-Cafe24SurroundAir pl-4 pr-3 pb-[0.625rem]';
@@ -20,7 +19,6 @@ const UserListItem = ({ fullName, id, image }: UserListItemParams) => {
   const navigate = useNavigate();
   const { followMutation, unFollowMutation } = useFollowQuery();
   const { showModal, modalOpen, modalClose } = useModal();
-  const { showToast } = useToastContext();
 
   const handleToggleFollow = (id: string) => {
     if (!user) {
@@ -29,7 +27,6 @@ const UserListItem = ({ fullName, id, image }: UserListItemParams) => {
       const followingUserId = user.following.find(({ user }) => user === id);
       if (!followingUserId) {
         followMutation.mutate(id);
-        showToast('팔로우에 성공하셨습니다', 'success');
       } else {
         unFollowMutation.mutate(followingUserId._id);
       }
@@ -65,7 +62,7 @@ const UserListItem = ({ fullName, id, image }: UserListItemParams) => {
       <SubButton
         icon="star"
         key={id}
-        label="팔로우"
+        label="구독하기"
         color="violet"
         type={isFollowing(user) ? 'fill' : 'outline'}
         size="small"


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #281 
## 📗 요구 사항과 구현 내용 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 검색 페이지에서 구독 버튼의 label 이름이 '팔로우'였던 것을 수정하였습니다.
- 본인의 프로필 페이지가 아닌 프로필 페이지에서 구독하기 버튼과 구독 취소하기 버튼을 추가했습니다.
- useFollowQuery 훅을 수정했습니다.
  - 토스트 메시지 호출 부를 UI단에서 훅 내부로 옮겼습니다.
  - onSettled에 쿼리 키를 추가하여 프로필 페이지에서 변경 사항이 바로 적용되도록 하였습니다.
- 메시지 상수 파일에 구독, 구독취소 관련 메시지를 추가하였습니다.

## 📖 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📖 PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
